### PR TITLE
chore: add disallowed links rule to `.textlintrc.js` configuration

### DIFF
--- a/.textlintrc.js
+++ b/.textlintrc.js
@@ -4,6 +4,9 @@ module.exports = {
       allowed: {
         images: [/^\/public\/images\//],
       },
+      disallowed: {
+        links: [/^\.\//],
+      },
     },
   },
 };


### PR DESCRIPTION
This pull request includes a small change to the `.textlintrc.js` file. The change introduces a new `disallowed` property under `allowed` to specify disallowed links.

* [`.textlintrc.js`](diffhunk://#diff-b6512489def90a2f455833dc056c80f0fc91accd990eee2e3e7cf718ce7b76edR7-R9): Added `disallowed` property to restrict links starting with `./`.