### PR TITLE
chore: update `.markdownlint.json`

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -15,6 +15,7 @@
   },
   "no-inline-html": {
     "allowed_elements": [
+      "small",
       "sub",
       "sup",
       "u",
@@ -27,7 +28,8 @@
       "mark",
       "ruby",
       "rp",
-      "rt"
+      "rt",
+      "Badge"
     ]
   },
   "hr-style": {


### PR DESCRIPTION
This pull request includes changes to the `.markdownlint.json` file to allow additional HTML elements. The most important changes include adding the `small` and `Badge` elements to the list of allowed inline HTML elements.

* [`.markdownlint.json`](diffhunk://#diff-7acf5910ecddb0a88c58debaedb129a30ebad965e878f6ebba3dad5a4fd8758aR18): Added `small` to the `allowed_elements` list.
* [`.markdownlint.json`](diffhunk://#diff-7acf5910ecddb0a88c58debaedb129a30ebad965e878f6ebba3dad5a4fd8758aL30-R32): Added `Badge` to the `allowed_elements` list.