### PR TITLE
chore: add `.vitepress/cache/` to ignore lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # production
 build
 .next
+**/.vitepress/cache/
 
 # env
 .env

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -4,6 +4,7 @@ node_modules
 # production
 build
 .next
+**/.vitepress/cache/
 
 # files
 LICENSE.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ node_modules
 # production
 build
 .next
+**/.vitepress/cache/
 
 # env
 .env


### PR DESCRIPTION
This pull request includes updates to the `.markdownlintignore` and `.prettierignore` files to improve the handling of build cache directories.

Updates to ignore files:

* [`.markdownlintignore`](diffhunk://#diff-b5e89e929d119744a043caea30a5e49d7a9ea25e3253755760d5b6ec9bd24ca0R7): Added `**/.vitepress/cache/` to the list of ignored directories.
* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R7): Added `**/.vitepress/cache/` to the list of ignored directories.