### PR TITLE
chore(deps-dev): bump `clang-format-git` from `v1.3.0` to `v1.3.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.12.0",
-        "clang-format-git": "^1.3.0",
+        "clang-format-git": "^1.3.1",
         "concurrently": "^9.1.2",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^8.57.1",
@@ -3138,14 +3138,15 @@
       }
     },
     "node_modules/clang-format-git": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clang-format-git/-/clang-format-git-1.3.0.tgz",
-      "integrity": "sha512-Uc/cws+Idal16ygCSf3ryeEkW9IpvJKcLXm1uXGrG/ahg9lS0xkUQLOJYLxe1dfAE8dkXB9YBHlsra/XRrLhwA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/clang-format-git/-/clang-format-git-1.3.1.tgz",
+      "integrity": "sha512-QVTdIVlO/Lw/XFj6akb2b46Yiqg2ec9RmFuTO2YMq/tArOU9as00nOSYiWUs5RCFFzISO+eMi2gf9/PIUQCpQg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "clang-format-node": "^1.3.0"
+        "clang-format-node": "^1.3.1",
+        "shx": "^0.3.4"
       },
       "bin": {
         "clang-format-git": "build/cli.js",
@@ -3156,12 +3157,15 @@
       }
     },
     "node_modules/clang-format-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clang-format-node/-/clang-format-node-1.3.0.tgz",
-      "integrity": "sha512-bjhzAvxoUXu5fZvwD3V6+mQmVRRDmx41ZBwZoE43o1gNNmhKKCMn8Hurp3PmcQbucqjgTDwLRdd2AajVA0C7ng==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/clang-format-node/-/clang-format-node-1.3.1.tgz",
+      "integrity": "sha512-QhOC6e+KD0aaDduJLwn11jf0Yra3UzB+wk8rqiWZFajnDPwCYE697FfwUdwVlCO/OV4dsqclu2vYNZ/1BtmZTA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "shx": "^0.3.4"
+      },
       "bin": {
         "clang-format": "build/cli.js",
         "clang-format-node": "build/cli.js"
@@ -6027,6 +6031,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -9316,6 +9330,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -9811,6 +9837,87 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.12.0",
-    "clang-format-git": "^1.3.0",
+    "clang-format-git": "^1.3.1",
     "concurrently": "^9.1.2",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^8.57.1",


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file. The change updates the version of the `clang-format-git` dependency to the latest version.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L45-R45): Updated `clang-format-git` dependency from version `^1.3.0` to `^1.3.1`.