### PR TITLE
ci(*): update `lint` workflow permissions to allow read access to contents

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main') }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/lint.yml` file. The change adds permissions to read contents for the workflow. 

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R12): Added `permissions` section to grant read access to contents.