### PR TITLE
chore(*): update `lint-staged` and scripts

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,11 +1,11 @@
 export default {
   '*': [
-    'npx prettier --check --ignore-unknown',
+    'npx prettier --write --ignore-unknown',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint --fix',
   '*.{css,scss}': 'npx stylelint',
-  '*.md': 'npx markdownlint',
+  '*.md': 'npx markdownlint --fix',
   'src/docs/**/*.md': 'npx textlint -f pretty-error',
   '*.{h,c,cpp}': 'npx clang-format -n -Werror',
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fix:eslint": "npx eslint --fix",
     "fix:stylelint": "npx stylelint --fix **/*.{css,scss}",
     "fix:prettier": "npx prettier . --write --ignore-unknown",
+    "fix:markdownlint": "npx markdownlint **/*.md --fix",
     "fix:clangformat": "find . -name '*.h' -o -name '*.c' -o -name '*.cpp' -print0 | xargs -0 npx clang-format -i",
     "lint": "concurrently \"npm:lint:*\"",
     "lint:eslint": "npx eslint",


### PR DESCRIPTION
This pull request updates the linting configuration to enable automatic fixing for several tools and adds a new script for fixing markdown linting issues. These changes improve the developer experience by automating code formatting and linting fixes.

### Updates to linting configuration:

* [`lint-staged.config.mjs`](diffhunk://#diff-7de6c7dbbd1b286aac2271abff52aed05b83379c998f2158f357046f9fd06c7dL3-R8): Updated `prettier`, `eslint`, and `markdownlint` commands to include automatic fixing (`--write` or `--fix` flags). This ensures that staged files are automatically formatted and linted during commits.

### New script addition:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added a new `fix:markdownlint` script to allow developers to fix markdown linting issues across the codebase with a single command.