### PR TITLE
chore(*): update domain name in favor of `lumir.page`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 📖blog.lumir.page
-    url: https://blog.lumir.page
+  - name: 📖lumir.page
+    url: https://lumir.page
     about: LuMir's Blog. 루밀의 블로그.📖

--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -1,6 +1,6 @@
 lumirlumir/lumirlumir-configs:
   - source: ./.github/sync-client.yml
-    dest: ./clients/web-blog.lumir.page.yml
+    dest: ./clients/web-lumir.page.yml
   # ./.github/ISSUE_TEMPLATE
   - source: ./.github/ISSUE_TEMPLATE/1-bug.md
     dest: ./configs/.github/ISSUE_TEMPLATE/1-bug.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Change Log
 
-See [Releases🎉](https://github.com/lumirlumir/web-blog.lumir.page/releases) and [Tags🏷️](https://github.com/lumirlumir/web-blog.lumir.page/tags) in GitHub.
+See [Releases🎉](https://github.com/lumirlumir/web-lumir.page/releases) and [Tags🏷️](https://github.com/lumirlumir/web-lumir.page/tags) in GitHub.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# blog.lumir.page
+# lumir.page
 
 LuMir's Blog. 루밀의 블로그.📖

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "web-blog.lumir.page",
+  "name": "web-lumir.page",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,7 +1,7 @@
 import { join } from 'path'; // eslint-disable-line -- TODO
 
 // Website
-export const WEBSITE_NAME = 'blog.lumir.page';
+export const WEBSITE_NAME = 'lumir.page';
 export const WEBSITE_URL = `https://${WEBSITE_NAME}`;
 
 // GitHub Repository, Ref: https://docs.github.com/en/rest/repos/repos


### PR DESCRIPTION
This pull request includes updates to rename references from "blog.lumir.page" to "lumir.page" across multiple files for consistency and to reflect a branding change. Below are the most important changes grouped by theme.

### Configuration and Metadata Updates:
* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L3-R4): Updated the blog name and URL in the contact links to "lumir.page" and `https://lumir.page`.
* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1L3-R3): Changed the destination file path to use "web-lumir.page" instead of "web-blog.lumir.page".

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3): Updated GitHub release and tag links to point to the new "web-lumir.page" repository.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Changed the project title from "blog.lumir.page" to "lumir.page".

### Code Updates:
* [`src/constants/index.js`](diffhunk://#diff-93bc4dfd82efb9b25f0781275701f8ad5c308045ab32abf1fae1dd5db8c3c3daL4-R4): Renamed the `WEBSITE_NAME` constant from "blog.lumir.page" to "lumir.page" to reflect the updated branding.