### PR TITLE
ci(*): speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint
+name: ci
 
 on:
   push:
@@ -26,15 +26,9 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: npm
+          cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
-      - name: Set up cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Set up node_modules
+      - name: Install dependencies
         run: npm ci
 
       - name: Build
@@ -43,7 +37,7 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  test: # TODO: Detach this job from the `lint` job
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -54,18 +48,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: npm
+          cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
-      - name: Set up cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Set up node_modules
+      - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright Browsers
+      - name: Install playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Build


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow by renaming the workflow file, simplifying dependency caching, and cleaning up redundant steps. The changes aim to streamline the CI process and improve maintainability.

**Workflow file renaming and generalization:**
* Renamed the workflow file from `.github/workflows/lint.yml` to `.github/workflows/ci.yml` and updated the workflow name from "lint" to "ci" to better reflect its broader purpose.

**Dependency management and caching improvements:**
* Simplified npm caching by relying solely on the built-in caching feature of `actions/setup-node@v6` (using the `cache: npm` option), and removed the separate `actions/cache` step for both lint and test jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL29-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL57-R56)
* Combined the setup and installation of dependencies into a single "Install dependencies" step using `npm ci`, replacing the previous "Set up node_modules" step. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL29-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL57-R56)

**Job and step cleanup:**
* Updated the Playwright installation step to use a more consistent naming convention ("Install playwright browsers").
* Removed a TODO comment about detaching the test job from lint, indicating a move towards clearer job separation.