### PR TITLE
refactor(blog): replace reset CSS with normalize CSS

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -33,8 +33,8 @@ import Title from '@/components/header/title';
 import { GOOGLE_GA_ID } from '@/constants';
 import { getGithubUsers } from '@/utils/fetch';
 
+import '@/styles/index.css';
 import 'katex/dist/katex.min.css'; // Import KaTeX CSS globally
-import '../styles/index.css';
 
 // --------------------------------------------------------------------------------
 // Named Export

--- a/apps/blog/src/components/aside/categories.module.css
+++ b/apps/blog/src/components/aside/categories.module.css
@@ -52,7 +52,6 @@
       grid-area: 1 / 3 / 3 / 4;
 
       & > span {
-        box-sizing: content-box;
         width: var(--size-20);
         height: var(--size-20);
         font-size: var(--size-12);

--- a/apps/blog/src/components/aside/categories.module.css
+++ b/apps/blog/src/components/aside/categories.module.css
@@ -8,6 +8,9 @@
   /* properties */
   display: flex;
   flex-direction: column;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 
   /* selectors */
   & > li > a {
@@ -49,6 +52,7 @@
       grid-area: 1 / 3 / 3 / 4;
 
       & > span {
+        box-sizing: content-box;
         width: var(--size-20);
         height: var(--size-20);
         font-size: var(--size-12);

--- a/apps/blog/src/components/aside/links.module.css
+++ b/apps/blog/src/components/aside/links.module.css
@@ -1,5 +1,7 @@
 .links {
   padding: var(--size-8) 0 var(--size-16);
+  margin: 0;
+  list-style: none;
 
   & > li > a {
     flex-direction: column;

--- a/apps/blog/src/components/aside/links.module.css
+++ b/apps/blog/src/components/aside/links.module.css
@@ -1,6 +1,5 @@
 .links {
   padding: var(--size-8) 0 var(--size-16);
-  margin: 0;
   list-style: none;
 
   & > li > a {

--- a/apps/blog/src/components/header/doc-search.css
+++ b/apps/blog/src/components/header/doc-search.css
@@ -31,6 +31,9 @@
   width: 100%;
   height: 100%;
   margin: 0;
+  font-family: arial, helvetica, sans-serif;
+  font-size: 13.3333px;
+  line-height: normal;
   border-radius: var(--size-border-radius);
   transition: all 0.3s ease-in-out;
 
@@ -43,6 +46,7 @@
 
 .DocSearch-Button-Placeholder {
   font-size: var(--size-14);
+  line-height: normal;
   letter-spacing: var(--size-letter-spacing-medium);
 }
 

--- a/apps/blog/src/components/header/doc-search.css
+++ b/apps/blog/src/components/header/doc-search.css
@@ -31,9 +31,6 @@
   width: 100%;
   height: 100%;
   margin: 0;
-  font-family: arial, helvetica, sans-serif;
-  font-size: 13.3333px;
-  line-height: normal;
   border-radius: var(--size-border-radius);
   transition: all 0.3s ease-in-out;
 

--- a/apps/blog/src/components/header/doc-search.css
+++ b/apps/blog/src/components/header/doc-search.css
@@ -46,7 +46,6 @@
 
 .DocSearch-Button-Placeholder {
   font-size: var(--size-14);
-  line-height: normal;
   letter-spacing: var(--size-letter-spacing-medium);
 }
 

--- a/apps/blog/src/components/layouts/body.module.css
+++ b/apps/blog/src/components/layouts/body.module.css
@@ -3,6 +3,7 @@
   grid-template-rows: var(--size-header-height) 1fr;
   grid-template-columns: var(--size-sidebar-width) 1fr;
   font-family: var(--font-stack-system);
+  line-height: 1;
   color: var(--color-fg-default);
   background-color: var(--color-bg-inset);
 

--- a/apps/blog/src/components/nav/sort.module.css
+++ b/apps/blog/src/components/nav/sort.module.css
@@ -1,3 +1,9 @@
+.list {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
 .sort-item {
   --grid-template-rows-1: var(--size-24);
   --grid-template-rows-2: var(--size-16);

--- a/apps/blog/src/components/nav/sort.tsx
+++ b/apps/blog/src/components/nav/sort.tsx
@@ -43,7 +43,7 @@ function SortContainer({ children }: PropsWithChildren) {
           {isOpen ? <FaAngleUp /> : <FaAngleDown />}
         </div>
       </div>
-      {isOpen ? <ul>{children}</ul> : null}
+      {isOpen ? <ul className={styles.list}>{children}</ul> : null}
     </div>
   );
 }

--- a/apps/blog/src/styles/index.css
+++ b/apps/blog/src/styles/index.css
@@ -1,5 +1,5 @@
 @import './animations.css';
 @import './markdown.css';
-@import './reset.css';
+@import './normalize.css';
 @import './utilities.css';
 @import './variables.css';

--- a/apps/blog/src/styles/normalize.css
+++ b/apps/blog/src/styles/normalize.css
@@ -10,7 +10,6 @@ Document
 1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
 2. Correct the line height in all browsers.
 3. Prevent adjustments of font size after orientation changes in iOS.
-4. Use a more readable tab size (opinionated).
 */
 
 html {
@@ -19,7 +18,6 @@ html {
     'Segoe UI Emoji'; /* 1 */
   line-height: 1.15; /* 2 */
   -webkit-text-size-adjust: 100%; /* 3 */
-  tab-size: 4; /* 4 */
 }
 
 /*

--- a/apps/blog/src/styles/normalize.css
+++ b/apps/blog/src/styles/normalize.css
@@ -7,18 +7,6 @@ Document
 */
 
 /**
-Use a better box model (opinionated).
-*/
-
-/*
-*,
-::before,
-::after {
-  box-sizing: border-box;
-}
-*/
-
-/**
 1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
 2. Correct the line height in all browsers.
 3. Prevent adjustments of font size after orientation changes in iOS.

--- a/apps/blog/src/styles/reset.css
+++ b/apps/blog/src/styles/reset.css
@@ -1,137 +1,225 @@
-@layer base {
-  html:not(.markdown-body *),
-  body:not(.markdown-body *),
-  div:not(.markdown-body *),
-  span:not(.markdown-body *),
-  applet:not(.markdown-body *),
-  object:not(.markdown-body *),
-  iframe:not(.markdown-body *),
-  h1:not(.markdown-body *),
-  h2:not(.markdown-body *),
-  h3:not(.markdown-body *),
-  h4:not(.markdown-body *),
-  h5:not(.markdown-body *),
-  h6:not(.markdown-body *),
-  p:not(.markdown-body *),
-  blockquote:not(.markdown-body *),
-  pre:not(.markdown-body *),
-  a:not(.markdown-body *),
-  abbr:not(.markdown-body *),
-  acronym:not(.markdown-body *),
-  address:not(.markdown-body *),
-  big:not(.markdown-body *),
-  cite:not(.markdown-body *),
-  code:not(.markdown-body *),
-  del:not(.markdown-body *),
-  dfn:not(.markdown-body *),
-  em:not(.markdown-body *),
-  img:not(.markdown-body *),
-  ins:not(.markdown-body *),
-  kbd:not(.markdown-body *),
-  q:not(.markdown-body *),
-  s:not(.markdown-body *),
-  samp:not(.markdown-body *),
-  small:not(.markdown-body *),
-  strike:not(.markdown-body *),
-  strong:not(.markdown-body *),
-  sub:not(.markdown-body *),
-  sup:not(.markdown-body *),
-  tt:not(.markdown-body *),
-  var:not(.markdown-body *),
-  b:not(.markdown-body *),
-  u:not(.markdown-body *),
-  i:not(.markdown-body *),
-  center:not(.markdown-body *),
-  dl:not(.markdown-body *),
-  dt:not(.markdown-body *),
-  dd:not(.markdown-body *),
-  ol:not(.markdown-body *),
-  ul:not(.markdown-body *),
-  li:not(.markdown-body *),
-  fieldset:not(.markdown-body *),
-  form:not(.markdown-body *),
-  label:not(.markdown-body *),
-  legend:not(.markdown-body *),
-  table:not(.markdown-body *),
-  caption:not(.markdown-body *),
-  tbody:not(.markdown-body *),
-  tfoot:not(.markdown-body *),
-  thead:not(.markdown-body *),
-  tr:not(.markdown-body *),
-  th:not(.markdown-body *),
-  td:not(.markdown-body *),
-  article:not(.markdown-body *),
-  aside:not(.markdown-body *),
-  canvas:not(.markdown-body *),
-  details:not(.markdown-body *),
-  embed:not(.markdown-body *),
-  figure:not(.markdown-body *),
-  figcaption:not(.markdown-body *),
-  footer:not(.markdown-body *),
-  header:not(.markdown-body *),
-  hgroup:not(.markdown-body *),
-  menu:not(.markdown-body *),
-  nav:not(.markdown-body *),
-  output:not(.markdown-body *),
-  ruby:not(.markdown-body *),
-  section:not(.markdown-body *),
-  summary:not(.markdown-body *),
-  time:not(.markdown-body *),
-  mark:not(.markdown-body *),
-  audio:not(.markdown-body *),
-  video:not(.markdown-body *) {
-    padding: 0;
-    margin: 0;
-    font: inherit;
-    font-size: 100%;
-    vertical-align: baseline;
-    border: 0;
-  }
+/* stylelint-disable */
+/*! modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
-  /* HTML5 display-role reset for older browsers */
-  article:not(.markdown-body *),
-  aside:not(.markdown-body *),
-  details:not(.markdown-body *),
-  figcaption:not(.markdown-body *),
-  figure:not(.markdown-body *),
-  footer:not(.markdown-body *),
-  header:not(.markdown-body *),
-  hgroup:not(.markdown-body *),
-  menu:not(.markdown-body *),
-  nav:not(.markdown-body *),
-  section:not(.markdown-body *) {
-    display: block;
-  }
+/*
+Document
+========
+*/
 
-  body:not(.markdown-body *) {
-    line-height: 1;
-  }
+/**
+Use a better box model (opinionated).
+*/
 
-  ol:not(.markdown-body *),
-  ul:not(.markdown-body *) {
-    list-style: none;
-  }
+/*
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+*/
 
-  blockquote:not(.markdown-body *),
-  q:not(.markdown-body *) {
-    quotes: none;
-  }
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the line height in all browsers.
+3. Prevent adjustments of font size after orientation changes in iOS.
+4. Use a more readable tab size (opinionated).
+*/
 
-  blockquote:not(.markdown-body *)::before,
-  blockquote:not(.markdown-body *)::after,
-  q:not(.markdown-body *)::before,
-  q:not(.markdown-body *)::after {
-    content: '';
-    content: none;
-  }
+html {
+  font-family:
+    system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji'; /* 1 */
+  line-height: 1.15; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 3 */
+  tab-size: 4; /* 4 */
+}
 
-  table:not(.markdown-body *) {
-    border-spacing: 0;
-    border-collapse: collapse;
-  }
+/*
+Sections
+========
+*/
 
-  a:not(.markdown-body *) {
-    color: inherit;
-    text-decoration: none;
-  }
+/**
+Remove the margin in all browsers.
+*/
+
+body {
+  margin: 0;
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct font weight in Chrome and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family:
+    ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  border-color: currentcolor;
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+App base
+========
+*/
+
+a {
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
This pull request updates the global CSS reset and normalization strategy for the blog app, replacing a custom reset with the widely-used `modern-normalize` for more consistent cross-browser styling. It also refines list and typography styles across several components for improved layout and appearance.

**Global CSS and Normalization:**
* Replaced the custom `reset.css` with `modern-normalize` by importing `normalize.css` in `index.css`, and removed the old reset file. This provides a more standard and maintainable baseline for browser styles. [[1]](diffhunk://#diff-6960b1a8a9e41809a5b71616ba46c1fd3deba56bc13db75bd349537af041ce62L3-R3) [[2]](diffhunk://#diff-b2d227ff13648eeca9a1502c343356019f78d1da5e9594a875f12019e5d323e7R1-R211) [[3]](diffhunk://#diff-0ff2c793ac13bb49ee0b138bc8a035ad90c7c379b04cad360999fa8d4c164479L1-L137)
* Updated the global CSS import in `layout.tsx` to use the correct path for `index.css`.

**List and Layout Styling:**
* Standardized list styles in navigation and sidebar components by adding `list-style: none;`, `padding: 0;`, and `margin: 0;` to relevant CSS modules for categories, links, and sort lists. [[1]](diffhunk://#diff-d0f6796c30ddc210e9ea302465078fa6a07fbab3504a6a5c3dd6e007eb602f7bR11-R13) [[2]](diffhunk://#diff-9be6889cf14cadac346a120b07f5a6aa9a9448529c50fa5f67185faefb91a999R3) [[3]](diffhunk://#diff-7ed938d067722c716d1e63de23239b911e555d59400b44c00666a8698640971cR1-R6) [[4]](diffhunk://#diff-8c533d0178d1c13ac3478a342d455d2341afc82349603257ecd84aa9b2cd430fL46-R46)
* Set `line-height: 1;` for the main body layout to improve text vertical alignment.

**Typography and Input Styling:**
* Enhanced the appearance of the search input by specifying font family, size, and line height for better consistency with the rest of the app.