### PR TITLE
refactor(blog): markdown CSS to use native nesting

### DIFF
--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -9,16 +9,6 @@
   word-wrap: break-word;
   scroll-behavior: auto !important;
 
-  & :is(h1, h2, h3, h4, h5, h6):hover .anchor .octicon-link:before {
-    width: 16px;
-    height: 16px;
-    content: ' ';
-    display: inline-block;
-    background-color: currentColor;
-    -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-    mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-  }
-
   & details,
   & figcaption,
   & figure {
@@ -414,36 +404,50 @@
     margin-bottom: 0;
   }
 
-  & :is(h1, h2, h3, h4, h5, h6) .octicon-link {
-    color: var(--color-fg-default);
-    vertical-align: middle;
-    visibility: hidden;
+  & :is(h1, h2, h3, h4, h5, h6) {
+    & .octicon-link {
+      color: var(--color-fg-default);
+      vertical-align: middle;
+      visibility: hidden;
+    }
+
+    &:hover .anchor {
+      text-decoration: none;
+
+      & .octicon-link {
+        visibility: visible;
+
+        &:before {
+          width: 16px;
+          height: 16px;
+          content: ' ';
+          display: inline-block;
+          background-color: currentColor;
+          -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+          mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+        }
+      }
+    }
+
+    & :is(tt, code) {
+      padding: 0 0.2em;
+      font-size: inherit;
+    }
   }
 
-  & :is(h1, h2, h3, h4, h5, h6):hover .anchor {
-    text-decoration: none;
-  }
+  & summary {
+    & :is(h1, h2, h3, h4, h5, h6) {
+      display: inline-block;
 
-  & :is(h1, h2, h3, h4, h5, h6):hover .anchor .octicon-link {
-    visibility: visible;
-  }
+      & .anchor {
+        margin-left: -40px;
+      }
+    }
 
-  & :is(h1, h2, h3, h4, h5, h6) :is(tt, code) {
-    padding: 0 0.2em;
-    font-size: inherit;
-  }
-
-  & summary :is(h1, h2, h3, h4, h5, h6) {
-    display: inline-block;
-  }
-
-  & summary :is(h1, h2, h3, h4, h5, h6) .anchor {
-    margin-left: -40px;
-  }
-
-  & summary :is(h1, h2) {
-    padding-bottom: 0;
-    border-bottom: 0;
+    & :is(h1, h2) {
+      padding-bottom: 0;
+      border-bottom: 0;
+    }
   }
 
   & :is(ul, ol).no-list {

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -1022,61 +1022,61 @@
     margin-bottom: var(--size-16);
     color: inherit;
     border-left: 0.25em solid var(--color-border-default);
-  }
 
-  & .markdown-alert > :first-child {
-    margin-top: 0;
-  }
+    & > :first-child {
+      margin-top: 0;
+    }
 
-  & .markdown-alert > :last-child {
-    margin-bottom: 0;
-  }
+    & > :last-child {
+      margin-bottom: 0;
+    }
 
-  & .markdown-alert .markdown-alert-title {
-    display: flex;
-    font-weight: var(--text-weight-medium);
-    align-items: center;
-    line-height: 1;
-  }
+    & .markdown-alert-title {
+      display: flex;
+      font-weight: var(--text-weight-medium);
+      align-items: center;
+      line-height: 1;
+    }
 
-  & .markdown-alert.markdown-alert-note {
-    border-left-color: var(--color-border-accent-emphasis);
-  }
+    &.markdown-alert-note {
+      border-left-color: var(--color-border-accent-emphasis);
 
-  & .markdown-alert.markdown-alert-note .markdown-alert-title {
-    color: var(--color-fg-accent);
-  }
+      & .markdown-alert-title {
+        color: var(--color-fg-accent);
+      }
+    }
 
-  & .markdown-alert.markdown-alert-important {
-    border-left-color: var(--color-border-done-emphasis);
-  }
+    &.markdown-alert-important {
+      border-left-color: var(--color-border-done-emphasis);
 
-  & .markdown-alert.markdown-alert-important .markdown-alert-title {
-    color: var(--color-fg-done);
-  }
+      & .markdown-alert-title {
+        color: var(--color-fg-done);
+      }
+    }
 
-  & .markdown-alert.markdown-alert-warning {
-    border-left-color: var(--color-border-attention-emphasis);
-  }
+    &.markdown-alert-warning {
+      border-left-color: var(--color-border-attention-emphasis);
 
-  & .markdown-alert.markdown-alert-warning .markdown-alert-title {
-    color: var(--color-fg-attention);
-  }
+      & .markdown-alert-title {
+        color: var(--color-fg-attention);
+      }
+    }
 
-  & .markdown-alert.markdown-alert-tip {
-    border-left-color: var(--color-border-success-emphasis);
-  }
+    &.markdown-alert-tip {
+      border-left-color: var(--color-border-success-emphasis);
 
-  & .markdown-alert.markdown-alert-tip .markdown-alert-title {
-    color: var(--color-fg-success);
-  }
+      & .markdown-alert-title {
+        color: var(--color-fg-success);
+      }
+    }
 
-  & .markdown-alert.markdown-alert-caution {
-    border-left-color: var(--color-border-danger-emphasis);
-  }
+    &.markdown-alert-caution {
+      border-left-color: var(--color-border-danger-emphasis);
 
-  & .markdown-alert.markdown-alert-caution .markdown-alert-title {
-    color: var(--color-fg-danger);
+      & .markdown-alert-title {
+        color: var(--color-fg-danger);
+      }
+    }
   }
 
   & > *:first-child > .heading-element:first-child {

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -17,6 +17,19 @@
 
   & summary {
     display: list-item;
+
+    & :is(h1, h2) {
+      padding-bottom: 0;
+      border-bottom: 0;
+    }
+
+    & :is(h1, h2, h3, h4, h5, h6) {
+      display: inline-block;
+
+      & .anchor {
+        margin-left: -40px;
+      }
+    }
   }
 
   & [hidden] {
@@ -432,21 +445,6 @@
     & :is(tt, code) {
       padding: 0 0.2em;
       font-size: inherit;
-    }
-  }
-
-  & summary {
-    & :is(h1, h2, h3, h4, h5, h6) {
-      display: inline-block;
-
-      & .anchor {
-        margin-left: -40px;
-      }
-    }
-
-    & :is(h1, h2) {
-      padding-bottom: 0;
-      border-bottom: 0;
     }
   }
 

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -1004,14 +1004,6 @@
     vertical-align: middle;
   }
 
-  & ul:dir(rtl) .task-list-item-checkbox {
-    margin: 0 -1.6em 0.25em 0.2em;
-  }
-
-  & ol:dir(rtl) .task-list-item-checkbox {
-    margin: 0 -1.6em 0.25em 0.2em;
-  }
-
   & .contains-task-list:hover .task-list-item-convert-container,
   & .contains-task-list:focus-within .task-list-item-convert-container {
     display: block;

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -9,12 +9,7 @@
   word-wrap: break-word;
   scroll-behavior: auto !important;
 
-  & h1:hover .anchor .octicon-link:before,
-  & h2:hover .anchor .octicon-link:before,
-  & h3:hover .anchor .octicon-link:before,
-  & h4:hover .anchor .octicon-link:before,
-  & h5:hover .anchor .octicon-link:before,
-  & h6:hover .anchor .octicon-link:before {
+  & :is(h1, h2, h3, h4, h5, h6):hover .anchor .octicon-link:before {
     width: 16px;
     height: 16px;
     content: ' ';
@@ -315,15 +310,11 @@
     padding-left: 2em;
   }
 
-  & ol ol,
-  & ul ol {
+  & :is(ul, ol) ol {
     list-style-type: lower-roman;
   }
 
-  & ul ul ol,
-  & ul ol ol,
-  & ol ul ol,
-  & ol ol ol {
+  & :is(ul, ol) :is(ul, ol) ol {
     list-style-type: lower-alpha;
   }
 
@@ -423,77 +414,39 @@
     margin-bottom: 0;
   }
 
-  & h1 .octicon-link,
-  & h2 .octicon-link,
-  & h3 .octicon-link,
-  & h4 .octicon-link,
-  & h5 .octicon-link,
-  & h6 .octicon-link {
+  & :is(h1, h2, h3, h4, h5, h6) .octicon-link {
     color: var(--color-fg-default);
     vertical-align: middle;
     visibility: hidden;
   }
 
-  & h1:hover .anchor,
-  & h2:hover .anchor,
-  & h3:hover .anchor,
-  & h4:hover .anchor,
-  & h5:hover .anchor,
-  & h6:hover .anchor {
+  & :is(h1, h2, h3, h4, h5, h6):hover .anchor {
     text-decoration: none;
   }
 
-  & h1:hover .anchor .octicon-link,
-  & h2:hover .anchor .octicon-link,
-  & h3:hover .anchor .octicon-link,
-  & h4:hover .anchor .octicon-link,
-  & h5:hover .anchor .octicon-link,
-  & h6:hover .anchor .octicon-link {
+  & :is(h1, h2, h3, h4, h5, h6):hover .anchor .octicon-link {
     visibility: visible;
   }
 
-  & h1 tt,
-  & h1 code,
-  & h2 tt,
-  & h2 code,
-  & h3 tt,
-  & h3 code,
-  & h4 tt,
-  & h4 code,
-  & h5 tt,
-  & h5 code,
-  & h6 tt,
-  & h6 code {
+  & :is(h1, h2, h3, h4, h5, h6) :is(tt, code) {
     padding: 0 0.2em;
     font-size: inherit;
   }
 
-  & summary h1,
-  & summary h2,
-  & summary h3,
-  & summary h4,
-  & summary h5,
-  & summary h6 {
+  & summary :is(h1, h2, h3, h4, h5, h6) {
     display: inline-block;
   }
 
-  & summary h1 .anchor,
-  & summary h2 .anchor,
-  & summary h3 .anchor,
-  & summary h4 .anchor,
-  & summary h5 .anchor,
-  & summary h6 .anchor {
+  & summary :is(h1, h2, h3, h4, h5, h6) .anchor {
     margin-left: -40px;
   }
 
-  & summary h1,
-  & summary h2 {
+  & summary :is(h1, h2) {
     padding-bottom: 0;
     border-bottom: 0;
   }
 
-  & ul.no-list,
-  & ol.no-list {
+  & :is(ul, ol).no-list {
     padding: 0;
     list-style-type: none;
   }
@@ -522,10 +475,7 @@
     list-style-type: decimal;
   }
 
-  & ul ul,
-  & ul ol,
-  & ol ol,
-  & ol ul {
+  & :is(ul, ol) :is(ul, ol) {
     margin-top: 0;
     margin-bottom: 0;
   }
@@ -559,8 +509,7 @@
     font-weight: var(--text-weight-semibold);
   }
 
-  & table th,
-  & table td {
+  & table :is(th, td) {
     padding: 6px 13px;
     border: 1px solid var(--color-border-default);
   }
@@ -694,8 +643,7 @@
     border-radius: 6px;
   }
 
-  & code br,
-  & tt br {
+  & :is(code, tt) br {
     display: none;
   }
 
@@ -740,8 +688,7 @@
     border-radius: var(--size-border-radius);
   }
 
-  & pre code,
-  & pre tt {
+  & pre :is(code, tt) {
     display: inline;
     max-width: auto;
     padding: 0;
@@ -753,8 +700,7 @@
     border: 0;
   }
 
-  & .csv-data td,
-  & .csv-data th {
+  & .csv-data :is(td, th) {
     padding: 5px;
     overflow: hidden;
     font-size: 12px;
@@ -859,9 +805,7 @@
   & .pl-pds,
   & .pl-s .pl-pse .pl-s1,
   & .pl-sr,
-  & .pl-sr .pl-cce,
-  & .pl-sr .pl-sre,
-  & .pl-sr .pl-sra {
+  & .pl-sr :is(.pl-cce, .pl-sre, .pl-sra) {
     color: var(--color-syntax-string);
   }
 
@@ -1003,8 +947,7 @@
     vertical-align: middle;
   }
 
-  & .contains-task-list:hover .task-list-item-convert-container,
-  & .contains-task-list:focus-within .task-list-item-convert-container {
+  & .contains-task-list:is(:hover, :focus-within) .task-list-item-convert-container {
     display: block;
     width: auto;
     height: 24px;

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -1,7 +1,6 @@
 /* stylelint-disable */
 
 .markdown-body {
-  -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0;
   font-family: var(--font-stack-system);

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -9,1113 +9,1107 @@
   line-height: 1.5;
   word-wrap: break-word;
   scroll-behavior: auto !important;
-}
-
-.markdown-body .octicon {
-  display: inline-block;
-  fill: currentColor;
-  vertical-align: text-bottom;
-}
-
-.markdown-body h1:hover .anchor .octicon-link:before,
-.markdown-body h2:hover .anchor .octicon-link:before,
-.markdown-body h3:hover .anchor .octicon-link:before,
-.markdown-body h4:hover .anchor .octicon-link:before,
-.markdown-body h5:hover .anchor .octicon-link:before,
-.markdown-body h6:hover .anchor .octicon-link:before {
-  width: 16px;
-  height: 16px;
-  content: ' ';
-  display: inline-block;
-  background-color: currentColor;
-  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-}
-
-.markdown-body details,
-.markdown-body figcaption,
-.markdown-body figure {
-  display: block;
-}
-
-.markdown-body summary {
-  display: list-item;
-}
-
-.markdown-body [hidden] {
-  display: none !important;
-}
-
-.markdown-body a {
-  background-color: transparent;
-  color: var(--color-fg-accent);
-  text-decoration: none;
-}
-
-.markdown-body abbr[title] {
-  border-bottom: none;
-  -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
-}
-
-.markdown-body b,
-.markdown-body strong {
-  font-weight: var(--text-weight-semibold);
-}
-
-.markdown-body dfn {
-  font-style: italic;
-}
-
-.markdown-body h1 {
-  margin: 0.67em 0;
-  font-weight: var(--text-weight-semibold);
-  padding-bottom: 0.3em;
-  font-size: 2em;
-  border-bottom: 1px solid var(--color-border-muted);
-}
-
-/* custom */
-.markdown-body mark {
-  background-color: var(--color-main); /* default: var(--color-bg-attention-muted); */
-  border-radius: var(--size-border-radius); /* default: nothing */
-  padding: 0 var(--size-4); /* default: nothing */
-  color: var(--color-fg-default);
-}
-
-.markdown-body small {
-  font-size: 90%;
-}
-
-.markdown-body sub,
-.markdown-body sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-.markdown-body sub {
-  bottom: -0.25em;
-}
-
-.markdown-body sup {
-  top: -0.5em;
-}
-
-.markdown-body img {
-  border-style: none;
-  max-width: 100%;
-  box-sizing: content-box;
-  border-radius: var(--size-border-radius);
-}
-
-.markdown-body code,
-.markdown-body kbd,
-.markdown-body pre,
-.markdown-body samp {
-  font-family: monospace;
-  font-size: 1em;
-}
-
-.markdown-body figure {
-  margin: 1em var(--size-40);
-}
-
-.markdown-body hr {
-  box-sizing: content-box;
-  overflow: hidden;
-  background: transparent;
-  border-bottom: 1px solid var(--color-border-muted);
-  height: 0.25em;
-  padding: 0;
-  margin: var(--size-24) 0;
-  background-color: var(--color-border-default);
-  border: 0;
-}
-
-.markdown-body input {
-  font: inherit;
-  margin: 0;
-  overflow: visible;
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-}
-
-.markdown-body [type='button'],
-.markdown-body [type='reset'],
-.markdown-body [type='submit'] {
-  -webkit-appearance: button;
-  appearance: button;
-}
-
-.markdown-body [type='checkbox'],
-.markdown-body [type='radio'] {
-  box-sizing: border-box;
-  padding: 0;
-}
-
-.markdown-body [type='number']::-webkit-inner-spin-button,
-.markdown-body [type='number']::-webkit-outer-spin-button {
-  height: auto;
-}
-
-.markdown-body [type='search']::-webkit-search-cancel-button,
-.markdown-body [type='search']::-webkit-search-decoration {
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.markdown-body ::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
-.markdown-body ::-webkit-file-upload-button {
-  -webkit-appearance: button;
-  appearance: button;
-  font: inherit;
-}
-
-.markdown-body a:hover {
-  text-decoration: underline;
-}
-
-.markdown-body ::placeholder {
-  color: var(--color-fg-muted);
-  opacity: 1;
-}
-
-.markdown-body hr::before {
-  display: table;
-  content: '';
-}
-
-.markdown-body hr::after {
-  display: table;
-  clear: both;
-  content: '';
-}
-
-.markdown-body table {
-  border-spacing: 0;
-  border-collapse: collapse;
-  display: block;
-  width: max-content;
-  max-width: 100%;
-  overflow: auto;
-}
-
-.markdown-body td,
-.markdown-body th {
-  padding: 0;
-}
-
-.markdown-body details summary {
-  cursor: pointer;
-}
-
-.markdown-body a:focus,
-.markdown-body [role='button']:focus,
-.markdown-body input[type='radio']:focus,
-.markdown-body input[type='checkbox']:focus {
-  outline: 2px solid var(--color-focus-outline);
-  outline-offset: -2px;
-  box-shadow: none;
-}
-
-.markdown-body a:focus:not(:focus-visible),
-.markdown-body [role='button']:focus:not(:focus-visible),
-.markdown-body input[type='radio']:focus:not(:focus-visible),
-.markdown-body input[type='checkbox']:focus:not(:focus-visible) {
-  outline: solid 1px transparent;
-}
-
-.markdown-body a:focus-visible,
-.markdown-body [role='button']:focus-visible,
-.markdown-body input[type='radio']:focus-visible,
-.markdown-body input[type='checkbox']:focus-visible {
-  outline: 2px solid var(--color-focus-outline);
-  outline-offset: -2px;
-  box-shadow: none;
-}
-
-.markdown-body a:not([class]):focus,
-.markdown-body a:not([class]):focus-visible,
-.markdown-body input[type='radio']:focus,
-.markdown-body input[type='radio']:focus-visible,
-.markdown-body input[type='checkbox']:focus,
-.markdown-body input[type='checkbox']:focus-visible {
-  outline-offset: 0;
-}
-
-.markdown-body kbd {
-  display: inline-block;
-  padding: var(--size-4);
-  font: 11px var(--font-stack-monospace);
-  line-height: 10px;
-  color: var(--color-fg-default);
-  vertical-align: middle;
-  background-color: var(--color-bg-muted);
-  border: solid 1px var(--color-border-neutral-muted);
-  border-bottom-color: var(--color-border-neutral-muted);
-  border-radius: var(--size-border-radius);
-  box-shadow: inset 0 -1px 0 var(--color-border-neutral-muted);
-}
-
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin-top: var(--size-24);
-  margin-bottom: var(--size-16);
-  font-weight: var(--text-weight-semibold);
-  line-height: 1.25;
-}
-
-.markdown-body h2 {
-  font-weight: var(--text-weight-semibold);
-  padding-bottom: 0.3em;
-  font-size: 1.5em;
-  border-bottom: 1px solid var(--color-border-muted);
-}
-
-.markdown-body h3 {
-  font-weight: var(--text-weight-semibold);
-  font-size: 1.25em;
-}
-
-.markdown-body h4 {
-  font-weight: var(--text-weight-semibold);
-  font-size: 1em;
-}
-
-.markdown-body h5 {
-  font-weight: var(--text-weight-semibold);
-  font-size: 0.875em;
-}
-
-.markdown-body h6 {
-  font-weight: var(--text-weight-semibold);
-  font-size: 0.85em;
-  color: var(--color-fg-muted);
-}
-
-.markdown-body p {
-  margin-top: 0;
-  margin-bottom: 10px;
-}
-
-.markdown-body blockquote {
-  margin: 0;
-  padding: 0 1em;
-  color: var(--color-fg-muted);
-  border-left: 0.25em solid var(--color-border-default);
-}
-
-.markdown-body ul,
-.markdown-body ol {
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 2em;
-}
-
-.markdown-body ol ol,
-.markdown-body ul ol {
-  list-style-type: lower-roman;
-}
-
-.markdown-body ul ul ol,
-.markdown-body ul ol ol,
-.markdown-body ol ul ol,
-.markdown-body ol ol ol {
-  list-style-type: lower-alpha;
-}
-
-.markdown-body dd {
-  margin-left: 0;
-}
-
-.markdown-body tt,
-.markdown-body code,
-.markdown-body samp {
-  font-family: var(--font-stack-monospace);
-  font-size: 12px;
-}
-
-.markdown-body pre {
-  margin-top: 0;
-  margin-bottom: 0;
-  font-family: var(--font-stack-monospace);
-  font-size: 12px;
-  word-wrap: normal;
-}
-
-.markdown-body .octicon {
-  display: inline-block;
-  overflow: visible !important;
-  vertical-align: text-bottom;
-  fill: currentColor;
-}
-
-.markdown-body input::-webkit-outer-spin-button,
-.markdown-body input::-webkit-inner-spin-button {
-  margin: 0;
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.markdown-body .mr-2 {
-  margin-right: var(--size-8) !important;
-}
-
-.markdown-body::before {
-  display: table;
-  content: '';
-}
-
-.markdown-body::after {
-  display: table;
-  clear: both;
-  content: '';
-}
-
-.markdown-body > *:first-child {
-  margin-top: 0 !important;
-}
-
-.markdown-body > *:last-child {
-  margin-bottom: 0 !important;
-}
-
-.markdown-body a:not([href]) {
-  color: inherit;
-  text-decoration: none;
-}
-
-.markdown-body .absent {
-  color: var(--color-fg-danger);
-}
-
-.markdown-body .anchor {
-  float: left;
-  padding-right: var(--size-4);
-  margin-left: -20px;
-  line-height: 1;
-}
-
-.markdown-body .anchor:focus {
-  outline: none;
-}
-
-.markdown-body p,
-.markdown-body blockquote,
-.markdown-body ul,
-.markdown-body ol,
-.markdown-body dl,
-.markdown-body table,
-.markdown-body pre,
-.markdown-body details {
-  margin-top: 0;
-  margin-bottom: var(--size-16);
-}
-
-.markdown-body blockquote > :first-child {
-  margin-top: 0;
-}
-
-.markdown-body blockquote > :last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body h1 .octicon-link,
-.markdown-body h2 .octicon-link,
-.markdown-body h3 .octicon-link,
-.markdown-body h4 .octicon-link,
-.markdown-body h5 .octicon-link,
-.markdown-body h6 .octicon-link {
-  color: var(--color-fg-default);
-  vertical-align: middle;
-  visibility: hidden;
-}
-
-.markdown-body h1:hover .anchor,
-.markdown-body h2:hover .anchor,
-.markdown-body h3:hover .anchor,
-.markdown-body h4:hover .anchor,
-.markdown-body h5:hover .anchor,
-.markdown-body h6:hover .anchor {
-  text-decoration: none;
-}
-
-.markdown-body h1:hover .anchor .octicon-link,
-.markdown-body h2:hover .anchor .octicon-link,
-.markdown-body h3:hover .anchor .octicon-link,
-.markdown-body h4:hover .anchor .octicon-link,
-.markdown-body h5:hover .anchor .octicon-link,
-.markdown-body h6:hover .anchor .octicon-link {
-  visibility: visible;
-}
-
-.markdown-body h1 tt,
-.markdown-body h1 code,
-.markdown-body h2 tt,
-.markdown-body h2 code,
-.markdown-body h3 tt,
-.markdown-body h3 code,
-.markdown-body h4 tt,
-.markdown-body h4 code,
-.markdown-body h5 tt,
-.markdown-body h5 code,
-.markdown-body h6 tt,
-.markdown-body h6 code {
-  padding: 0 0.2em;
-  font-size: inherit;
-}
-
-.markdown-body summary h1,
-.markdown-body summary h2,
-.markdown-body summary h3,
-.markdown-body summary h4,
-.markdown-body summary h5,
-.markdown-body summary h6 {
-  display: inline-block;
-}
-
-.markdown-body summary h1 .anchor,
-.markdown-body summary h2 .anchor,
-.markdown-body summary h3 .anchor,
-.markdown-body summary h4 .anchor,
-.markdown-body summary h5 .anchor,
-.markdown-body summary h6 .anchor {
-  margin-left: -40px;
-}
-
-.markdown-body summary h1,
-.markdown-body summary h2 {
-  padding-bottom: 0;
-  border-bottom: 0;
-}
-
-.markdown-body ul.no-list,
-.markdown-body ol.no-list {
-  padding: 0;
-  list-style-type: none;
-}
-
-.markdown-body ol[type='a s'] {
-  list-style-type: lower-alpha;
-}
-
-.markdown-body ol[type='A s'] {
-  list-style-type: upper-alpha;
-}
-
-.markdown-body ol[type='i s'] {
-  list-style-type: lower-roman;
-}
-
-.markdown-body ol[type='I s'] {
-  list-style-type: upper-roman;
-}
-
-.markdown-body ol[type='1'] {
-  list-style-type: decimal;
-}
-
-.markdown-body div > ol:not([type]) {
-  list-style-type: decimal;
-}
-
-.markdown-body ul ul,
-.markdown-body ul ol,
-.markdown-body ol ol,
-.markdown-body ol ul {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.markdown-body li > p {
-  margin-top: var(--size-16);
-}
-
-.markdown-body li + li {
-  margin-top: 0.25em;
-}
-
-.markdown-body dl {
-  padding: 0;
-}
-
-.markdown-body dl dt {
-  padding: 0;
-  margin-top: var(--size-16);
-  font-size: 1em;
-  font-style: italic;
-  font-weight: var(--text-weight-semibold);
-}
-
-.markdown-body dl dd {
-  padding: 0 var(--size-16);
-  margin-bottom: var(--size-16);
-}
-
-.markdown-body table th {
-  font-weight: var(--text-weight-semibold);
-}
-
-.markdown-body table th,
-.markdown-body table td {
-  padding: 6px 13px;
-  border: 1px solid var(--color-border-default);
-}
-
-.markdown-body table td > :last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body table tr {
-  background-color: var(--color-bg-default);
-  border-top: 1px solid var(--color-border-muted);
-}
-
-.markdown-body table tr:nth-child(2n) {
-  background-color: var(--color-bg-muted);
-}
-
-.markdown-body table img {
-  background-color: transparent;
-}
-
-.markdown-body img[align='right'] {
-  padding-left: 20px;
-}
-
-.markdown-body img[align='left'] {
-  padding-right: 20px;
-}
-
-.markdown-body .emoji {
-  max-width: none;
-  vertical-align: text-top;
-  background-color: transparent;
-}
-
-.markdown-body span.frame {
-  display: block;
-  overflow: hidden;
-}
-
-.markdown-body span.frame > span {
-  display: block;
-  float: left;
-  width: auto;
-  padding: 7px;
-  margin: 13px 0 0;
-  overflow: hidden;
-  border: 1px solid var(--color-border-default);
-}
-
-.markdown-body span.frame span img {
-  display: block;
-  float: left;
-}
-
-.markdown-body span.frame span span {
-  display: block;
-  padding: 5px 0 0;
-  clear: both;
-  color: var(--color-fg-default);
-}
-
-.markdown-body span.align-center {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markdown-body span.align-center > span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: center;
-}
-
-.markdown-body span.align-center span img {
-  margin: 0 auto;
-  text-align: center;
-}
-
-.markdown-body span.align-right {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markdown-body span.align-right > span {
-  display: block;
-  margin: 13px 0 0;
-  overflow: hidden;
-  text-align: right;
-}
-
-.markdown-body span.align-right span img {
-  margin: 0;
-  text-align: right;
-}
-
-.markdown-body span.float-left {
-  display: block;
-  float: left;
-  margin-right: 13px;
-  overflow: hidden;
-}
-
-.markdown-body span.float-left span {
-  margin: 13px 0 0;
-}
-
-.markdown-body span.float-right {
-  display: block;
-  float: right;
-  margin-left: 13px;
-  overflow: hidden;
-}
-
-.markdown-body span.float-right > span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: right;
-}
-
-.markdown-body code,
-.markdown-body tt {
-  padding: 0.2em 0.4em;
-  margin: 0;
-  font-size: 85%;
-  white-space: break-spaces;
-  background-color: var(--color-bg-neutral-muted);
-  border-radius: 6px;
-}
-
-.markdown-body code br,
-.markdown-body tt br {
-  display: none;
-}
-
-.markdown-body del code {
-  text-decoration: inherit;
-}
-
-.markdown-body samp {
-  font-size: 85%;
-}
-
-.markdown-body pre code {
-  font-size: 100%;
-}
-
-.markdown-body pre > code {
-  padding: 0;
-  margin: 0;
-  word-break: normal;
-  white-space: pre;
-  background: transparent;
-  border: 0;
-}
-
-.markdown-body .highlight {
-  margin-bottom: var(--size-16);
-}
-
-.markdown-body .highlight pre {
-  margin-bottom: 0;
-  word-break: normal;
-}
-
-.markdown-body .highlight pre,
-.markdown-body pre {
-  padding: var(--size-16);
-  overflow: auto;
-  font-size: 85%;
-  line-height: 1.45;
-  color: var(--color-fg-default);
-  background-color: var(--color-bg-muted);
-  border-radius: var(--size-border-radius);
-}
-
-.markdown-body pre code,
-.markdown-body pre tt {
-  display: inline;
-  max-width: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
-  line-height: inherit;
-  word-wrap: normal;
-  background-color: transparent;
-  border: 0;
-}
-
-.markdown-body .csv-data td,
-.markdown-body .csv-data th {
-  padding: 5px;
-  overflow: hidden;
-  font-size: 12px;
-  line-height: 1;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.markdown-body .csv-data .blob-num {
-  padding: 10px var(--size-8) 9px;
-  text-align: right;
-  background: var(--color-bg-default);
-  border: 0;
-}
-
-.markdown-body .csv-data tr {
-  border-top: 0;
-}
-
-.markdown-body .csv-data th {
-  font-weight: var(--text-weight-semibold);
-  background: var(--color-bg-muted);
-  border-top: 0;
-}
-
-.markdown-body [data-footnote-ref]::before {
-  content: '[';
-}
-
-.markdown-body [data-footnote-ref]::after {
-  content: ']';
-}
-
-.markdown-body .footnotes {
-  font-size: 12px;
-  color: var(--color-fg-muted);
-  border-top: 1px solid var(--color-border-default);
-}
-
-.markdown-body .footnotes ol {
-  padding-left: var(--size-16);
-}
-
-.markdown-body .footnotes ol ul {
-  display: inline-block;
-  padding-left: var(--size-16);
-  margin-top: var(--size-16);
-}
-
-.markdown-body .footnotes li {
-  position: relative;
-}
-
-.markdown-body .footnotes li:target::before {
-  position: absolute;
-  top: calc(var(--size-8) * -1);
-  right: calc(var(--size-8) * -1);
-  bottom: calc(var(--size-8) * -1);
-  left: calc(var(--size-24) * -1);
-  pointer-events: none;
-  content: '';
-  border: 2px solid var(--color-border-accent-emphasis);
-  border-radius: var(--size-border-radius);
-}
-
-.markdown-body .footnotes li:target {
-  color: var(--color-fg-default);
-}
-
-.markdown-body .footnotes .data-footnote-backref g-emoji {
-  font-family: monospace;
-}
-
-.markdown-body .pl-c {
-  color: var(--color-syntax-comment);
-}
-
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
-  color: var(--color-syntax-constant);
-}
-
-.markdown-body .pl-e,
-.markdown-body .pl-en {
-  color: var(--color-syntax-entity);
-}
-
-.markdown-body .pl-smi,
-.markdown-body .pl-s .pl-s1 {
-  color: var(--color-syntax-storage-modifier-import);
-}
-
-.markdown-body .pl-ent {
-  color: var(--color-syntax-entity-tag);
-}
-
-.markdown-body .pl-k {
-  color: var(--color-syntax-keyword);
-}
-
-.markdown-body .pl-s,
-.markdown-body .pl-pds,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sre,
-.markdown-body .pl-sr .pl-sra {
-  color: var(--color-syntax-string);
-}
-
-.markdown-body .pl-v,
-.markdown-body .pl-smw {
-  color: var(--color-syntax-variable);
-}
-
-.markdown-body .pl-bu {
-  color: var(--color-syntax-brackethighlighter-unmatched);
-}
-
-.markdown-body .pl-ii {
-  color: var(--color-syntax-invalid-illegal-text);
-  background-color: var(--color-syntax-invalid-illegal-bg);
-}
-
-.markdown-body .pl-c2 {
-  color: var(--color-syntax-carriage-return-text);
-  background-color: var(--color-syntax-carriage-return-bg);
-}
-
-.markdown-body .pl-sr .pl-cce {
-  font-weight: bold;
-  color: var(--color-syntax-string-regexp);
-}
-
-.markdown-body .pl-ml {
-  color: var(--color-syntax-markup-list);
-}
-
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
-  font-weight: bold;
-  color: var(--color-syntax-markup-heading);
-}
-
-.markdown-body .pl-mi {
-  font-style: italic;
-  color: var(--color-syntax-markup-italic);
-}
-
-.markdown-body .pl-mb {
-  font-weight: bold;
-  color: var(--color-syntax-markup-bold);
-}
-
-.markdown-body .pl-md {
-  color: var(--color-syntax-markup-deleted-text);
-  background-color: var(--color-syntax-markup-deleted-bg);
-}
-
-.markdown-body .pl-mi1 {
-  color: var(--color-syntax-markup-inserted-text);
-  background-color: var(--color-syntax-markup-inserted-bg);
-}
-
-.markdown-body .pl-mc {
-  color: var(--color-syntax-markup-changed-text);
-  background-color: var(--color-syntax-markup-changed-bg);
-}
-
-.markdown-body .pl-mi2 {
-  color: var(--color-syntax-markup-ignored-text);
-  background-color: var(--color-syntax-markup-ignored-bg);
-}
-
-.markdown-body .pl-mdr {
-  font-weight: bold;
-  color: var(--color-syntax-meta-diff-range);
-}
-
-.markdown-body .pl-ba {
-  color: var(--color-syntax-brackethighlighter-angle);
-}
-
-.markdown-body .pl-sg {
-  color: var(--color-syntax-sublimelinter-gutter-mark);
-}
-
-.markdown-body .pl-corl {
-  text-decoration: underline;
-  color: var(--color-syntax-constant-other-reference-link);
-}
-
-.markdown-body [role='button']:focus:not(:focus-visible),
-.markdown-body [role='tabpanel'][tabindex='0']:focus:not(:focus-visible),
-.markdown-body button:focus:not(:focus-visible),
-.markdown-body summary:focus:not(:focus-visible),
-.markdown-body a:focus:not(:focus-visible) {
-  outline: none;
-  box-shadow: none;
-}
-
-.markdown-body [tabindex='0']:focus:not(:focus-visible),
-.markdown-body details-dialog:focus:not(:focus-visible) {
-  outline: none;
-}
-
-.markdown-body g-emoji {
-  display: inline-block;
-  min-width: 1ch;
-  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-  font-size: 1em;
-  font-style: normal !important;
-  font-weight: var(--text-weight-normal);
-  line-height: 1;
-  vertical-align: -0.075em;
-}
-
-.markdown-body g-emoji img {
-  width: 1em;
-  height: 1em;
-}
-
-.markdown-body .task-list-item {
-  list-style-type: none;
-}
-
-.markdown-body .task-list-item label {
-  font-weight: var(--text-weight-normal);
-}
-
-.markdown-body .task-list-item.enabled label {
-  cursor: pointer;
-}
-
-.markdown-body .task-list-item + .task-list-item {
-  margin-top: var(--size-4);
-}
-
-.markdown-body .task-list-item .handle {
-  display: none;
-}
-
-.markdown-body .task-list-item-checkbox {
-  margin: 0 0.2em 0.25em -1.4em;
-  vertical-align: middle;
-}
-
-.markdown-body ul:dir(rtl) .task-list-item-checkbox {
-  margin: 0 -1.6em 0.25em 0.2em;
-}
-
-.markdown-body ol:dir(rtl) .task-list-item-checkbox {
-  margin: 0 -1.6em 0.25em 0.2em;
-}
-
-.markdown-body .contains-task-list:hover .task-list-item-convert-container,
-.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
-  display: block;
-  width: auto;
-  height: 24px;
-  overflow: visible;
-  clip: auto;
-}
-
-.markdown-body ::-webkit-calendar-picker-indicator {
-  filter: invert(50%);
-}
-
-.markdown-body .markdown-alert {
-  padding: var(--size-8) var(--size-16);
-  margin-bottom: var(--size-16);
-  color: inherit;
-  border-left: 0.25em solid var(--color-border-default);
-}
-
-.markdown-body .markdown-alert > :first-child {
-  margin-top: 0;
-}
-
-.markdown-body .markdown-alert > :last-child {
-  margin-bottom: 0;
-}
-
-.markdown-body .markdown-alert .markdown-alert-title {
-  display: flex;
-  font-weight: var(--text-weight-medium);
-  align-items: center;
-  line-height: 1;
-}
-
-.markdown-body .markdown-alert.markdown-alert-note {
-  border-left-color: var(--color-border-accent-emphasis);
-}
-
-.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
-  color: var(--color-fg-accent);
-}
-
-.markdown-body .markdown-alert.markdown-alert-important {
-  border-left-color: var(--color-border-done-emphasis);
-}
-
-.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
-  color: var(--color-fg-done);
-}
-
-.markdown-body .markdown-alert.markdown-alert-warning {
-  border-left-color: var(--color-border-attention-emphasis);
-}
-
-.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
-  color: var(--color-fg-attention);
-}
-
-.markdown-body .markdown-alert.markdown-alert-tip {
-  border-left-color: var(--color-border-success-emphasis);
-}
-
-.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
-  color: var(--color-fg-success);
-}
-
-.markdown-body .markdown-alert.markdown-alert-caution {
-  border-left-color: var(--color-border-danger-emphasis);
-}
-
-.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
-  color: var(--color-fg-danger);
-}
-
-.markdown-body > *:first-child > .heading-element:first-child {
-  margin-top: 0 !important;
-}
-
-/* custom properties: used by `rehype-github-color` */
-
-.markdown-body .d-inline-block {
-  display: inline-block !important;
-}
-
-.markdown-body .ml-1 {
-  margin-left: 4px !important;
-}
-
-.markdown-body .color-border-subtle {
-  border-color: var(--color-border-subtle) !important;
-}
-
-.markdown-body .circle {
-  border-radius: 50% !important;
-}
-
-.markdown-body .border {
-  border: 1px solid var(--color-border-default) !important;
+
+  & h1:hover .anchor .octicon-link:before,
+  & h2:hover .anchor .octicon-link:before,
+  & h3:hover .anchor .octicon-link:before,
+  & h4:hover .anchor .octicon-link:before,
+  & h5:hover .anchor .octicon-link:before,
+  & h6:hover .anchor .octicon-link:before {
+    width: 16px;
+    height: 16px;
+    content: ' ';
+    display: inline-block;
+    background-color: currentColor;
+    -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+    mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  }
+
+  & details,
+  & figcaption,
+  & figure {
+    display: block;
+  }
+
+  & summary {
+    display: list-item;
+  }
+
+  & [hidden] {
+    display: none !important;
+  }
+
+  & a {
+    background-color: transparent;
+    color: var(--color-fg-accent);
+    text-decoration: none;
+  }
+
+  & abbr[title] {
+    border-bottom: none;
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+
+  & b,
+  & strong {
+    font-weight: var(--text-weight-semibold);
+  }
+
+  & dfn {
+    font-style: italic;
+  }
+
+  & h1 {
+    margin: 0.67em 0;
+    font-weight: var(--text-weight-semibold);
+    padding-bottom: 0.3em;
+    font-size: 2em;
+    border-bottom: 1px solid var(--color-border-muted);
+  }
+
+  /* custom */
+  & mark {
+    background-color: var(--color-main); /* default: var(--color-bg-attention-muted); */
+    border-radius: var(--size-border-radius); /* default: nothing */
+    padding: 0 var(--size-4); /* default: nothing */
+    color: var(--color-fg-default);
+  }
+
+  & small {
+    font-size: 90%;
+  }
+
+  & sub,
+  & sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  & sub {
+    bottom: -0.25em;
+  }
+
+  & sup {
+    top: -0.5em;
+  }
+
+  & img {
+    border-style: none;
+    max-width: 100%;
+    box-sizing: content-box;
+    border-radius: var(--size-border-radius);
+  }
+
+  & code,
+  & kbd,
+  & pre,
+  & samp {
+    font-family: monospace;
+    font-size: 1em;
+  }
+
+  & figure {
+    margin: 1em var(--size-40);
+  }
+
+  & hr {
+    box-sizing: content-box;
+    overflow: hidden;
+    background: transparent;
+    border-bottom: 1px solid var(--color-border-muted);
+    height: 0.25em;
+    padding: 0;
+    margin: var(--size-24) 0;
+    background-color: var(--color-border-default);
+    border: 0;
+  }
+
+  & input {
+    font: inherit;
+    margin: 0;
+    overflow: visible;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+  }
+
+  & [type='button'],
+  & [type='reset'],
+  & [type='submit'] {
+    -webkit-appearance: button;
+    appearance: button;
+  }
+
+  & [type='checkbox'],
+  & [type='radio'] {
+    box-sizing: border-box;
+    padding: 0;
+  }
+
+  & [type='number']::-webkit-inner-spin-button,
+  & [type='number']::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  & [type='search']::-webkit-search-cancel-button,
+  & [type='search']::-webkit-search-decoration {
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  & ::-webkit-input-placeholder {
+    color: inherit;
+    opacity: 0.54;
+  }
+
+  & ::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    appearance: button;
+    font: inherit;
+  }
+
+  & a:hover {
+    text-decoration: underline;
+  }
+
+  & ::placeholder {
+    color: var(--color-fg-muted);
+    opacity: 1;
+  }
+
+  & hr::before {
+    display: table;
+    content: '';
+  }
+
+  & hr::after {
+    display: table;
+    clear: both;
+    content: '';
+  }
+
+  & table {
+    border-spacing: 0;
+    border-collapse: collapse;
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
+  }
+
+  & td,
+  & th {
+    padding: 0;
+  }
+
+  & details summary {
+    cursor: pointer;
+  }
+
+  & a:focus,
+  & [role='button']:focus,
+  & input[type='radio']:focus,
+  & input[type='checkbox']:focus {
+    outline: 2px solid var(--color-focus-outline);
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
+  & a:focus:not(:focus-visible),
+  & [role='button']:focus:not(:focus-visible),
+  & input[type='radio']:focus:not(:focus-visible),
+  & input[type='checkbox']:focus:not(:focus-visible) {
+    outline: solid 1px transparent;
+  }
+
+  & a:focus-visible,
+  & [role='button']:focus-visible,
+  & input[type='radio']:focus-visible,
+  & input[type='checkbox']:focus-visible {
+    outline: 2px solid var(--color-focus-outline);
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
+  & a:not([class]):focus,
+  & a:not([class]):focus-visible,
+  & input[type='radio']:focus,
+  & input[type='radio']:focus-visible,
+  & input[type='checkbox']:focus,
+  & input[type='checkbox']:focus-visible {
+    outline-offset: 0;
+  }
+
+  & kbd {
+    display: inline-block;
+    padding: var(--size-4);
+    font: 11px var(--font-stack-monospace);
+    line-height: 10px;
+    color: var(--color-fg-default);
+    vertical-align: middle;
+    background-color: var(--color-bg-muted);
+    border: solid 1px var(--color-border-neutral-muted);
+    border-bottom-color: var(--color-border-neutral-muted);
+    border-radius: var(--size-border-radius);
+    box-shadow: inset 0 -1px 0 var(--color-border-neutral-muted);
+  }
+
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    margin-top: var(--size-24);
+    margin-bottom: var(--size-16);
+    font-weight: var(--text-weight-semibold);
+    line-height: 1.25;
+  }
+
+  & h2 {
+    font-weight: var(--text-weight-semibold);
+    padding-bottom: 0.3em;
+    font-size: 1.5em;
+    border-bottom: 1px solid var(--color-border-muted);
+  }
+
+  & h3 {
+    font-weight: var(--text-weight-semibold);
+    font-size: 1.25em;
+  }
+
+  & h4 {
+    font-weight: var(--text-weight-semibold);
+    font-size: 1em;
+  }
+
+  & h5 {
+    font-weight: var(--text-weight-semibold);
+    font-size: 0.875em;
+  }
+
+  & h6 {
+    font-weight: var(--text-weight-semibold);
+    font-size: 0.85em;
+    color: var(--color-fg-muted);
+  }
+
+  & p {
+    margin-top: 0;
+    margin-bottom: 10px;
+  }
+
+  & blockquote {
+    margin: 0;
+    padding: 0 1em;
+    color: var(--color-fg-muted);
+    border-left: 0.25em solid var(--color-border-default);
+  }
+
+  & ul,
+  & ol {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 2em;
+  }
+
+  & ol ol,
+  & ul ol {
+    list-style-type: lower-roman;
+  }
+
+  & ul ul ol,
+  & ul ol ol,
+  & ol ul ol,
+  & ol ol ol {
+    list-style-type: lower-alpha;
+  }
+
+  & dd {
+    margin-left: 0;
+  }
+
+  & tt,
+  & code,
+  & samp {
+    font-family: var(--font-stack-monospace);
+    font-size: 12px;
+  }
+
+  & pre {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(--font-stack-monospace);
+    font-size: 12px;
+    word-wrap: normal;
+  }
+
+  & .octicon {
+    display: inline-block;
+    overflow: visible !important;
+    vertical-align: text-bottom;
+    fill: currentColor;
+  }
+
+  & input::-webkit-outer-spin-button,
+  & input::-webkit-inner-spin-button {
+    margin: 0;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+
+  & .mr-2 {
+    margin-right: var(--size-8) !important;
+  }
+
+  &::before {
+    display: table;
+    content: '';
+  }
+
+  &::after {
+    display: table;
+    clear: both;
+    content: '';
+  }
+
+  & > *:first-child {
+    margin-top: 0 !important;
+  }
+
+  & > *:last-child {
+    margin-bottom: 0 !important;
+  }
+
+  & a:not([href]) {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  & .absent {
+    color: var(--color-fg-danger);
+  }
+
+  & .anchor {
+    float: left;
+    padding-right: var(--size-4);
+    margin-left: -20px;
+    line-height: 1;
+  }
+
+  & .anchor:focus {
+    outline: none;
+  }
+
+  & p,
+  & blockquote,
+  & ul,
+  & ol,
+  & dl,
+  & table,
+  & pre,
+  & details {
+    margin-top: 0;
+    margin-bottom: var(--size-16);
+  }
+
+  & blockquote > :first-child {
+    margin-top: 0;
+  }
+
+  & blockquote > :last-child {
+    margin-bottom: 0;
+  }
+
+  & h1 .octicon-link,
+  & h2 .octicon-link,
+  & h3 .octicon-link,
+  & h4 .octicon-link,
+  & h5 .octicon-link,
+  & h6 .octicon-link {
+    color: var(--color-fg-default);
+    vertical-align: middle;
+    visibility: hidden;
+  }
+
+  & h1:hover .anchor,
+  & h2:hover .anchor,
+  & h3:hover .anchor,
+  & h4:hover .anchor,
+  & h5:hover .anchor,
+  & h6:hover .anchor {
+    text-decoration: none;
+  }
+
+  & h1:hover .anchor .octicon-link,
+  & h2:hover .anchor .octicon-link,
+  & h3:hover .anchor .octicon-link,
+  & h4:hover .anchor .octicon-link,
+  & h5:hover .anchor .octicon-link,
+  & h6:hover .anchor .octicon-link {
+    visibility: visible;
+  }
+
+  & h1 tt,
+  & h1 code,
+  & h2 tt,
+  & h2 code,
+  & h3 tt,
+  & h3 code,
+  & h4 tt,
+  & h4 code,
+  & h5 tt,
+  & h5 code,
+  & h6 tt,
+  & h6 code {
+    padding: 0 0.2em;
+    font-size: inherit;
+  }
+
+  & summary h1,
+  & summary h2,
+  & summary h3,
+  & summary h4,
+  & summary h5,
+  & summary h6 {
+    display: inline-block;
+  }
+
+  & summary h1 .anchor,
+  & summary h2 .anchor,
+  & summary h3 .anchor,
+  & summary h4 .anchor,
+  & summary h5 .anchor,
+  & summary h6 .anchor {
+    margin-left: -40px;
+  }
+
+  & summary h1,
+  & summary h2 {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  & ul.no-list,
+  & ol.no-list {
+    padding: 0;
+    list-style-type: none;
+  }
+
+  & ol[type='a s'] {
+    list-style-type: lower-alpha;
+  }
+
+  & ol[type='A s'] {
+    list-style-type: upper-alpha;
+  }
+
+  & ol[type='i s'] {
+    list-style-type: lower-roman;
+  }
+
+  & ol[type='I s'] {
+    list-style-type: upper-roman;
+  }
+
+  & ol[type='1'] {
+    list-style-type: decimal;
+  }
+
+  & div > ol:not([type]) {
+    list-style-type: decimal;
+  }
+
+  & ul ul,
+  & ul ol,
+  & ol ol,
+  & ol ul {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  & li > p {
+    margin-top: var(--size-16);
+  }
+
+  & li + li {
+    margin-top: 0.25em;
+  }
+
+  & dl {
+    padding: 0;
+  }
+
+  & dl dt {
+    padding: 0;
+    margin-top: var(--size-16);
+    font-size: 1em;
+    font-style: italic;
+    font-weight: var(--text-weight-semibold);
+  }
+
+  & dl dd {
+    padding: 0 var(--size-16);
+    margin-bottom: var(--size-16);
+  }
+
+  & table th {
+    font-weight: var(--text-weight-semibold);
+  }
+
+  & table th,
+  & table td {
+    padding: 6px 13px;
+    border: 1px solid var(--color-border-default);
+  }
+
+  & table td > :last-child {
+    margin-bottom: 0;
+  }
+
+  & table tr {
+    background-color: var(--color-bg-default);
+    border-top: 1px solid var(--color-border-muted);
+  }
+
+  & table tr:nth-child(2n) {
+    background-color: var(--color-bg-muted);
+  }
+
+  & table img {
+    background-color: transparent;
+  }
+
+  & img[align='right'] {
+    padding-left: 20px;
+  }
+
+  & img[align='left'] {
+    padding-right: 20px;
+  }
+
+  & .emoji {
+    max-width: none;
+    vertical-align: text-top;
+    background-color: transparent;
+  }
+
+  & span.frame {
+    display: block;
+    overflow: hidden;
+  }
+
+  & span.frame > span {
+    display: block;
+    float: left;
+    width: auto;
+    padding: 7px;
+    margin: 13px 0 0;
+    overflow: hidden;
+    border: 1px solid var(--color-border-default);
+  }
+
+  & span.frame span img {
+    display: block;
+    float: left;
+  }
+
+  & span.frame span span {
+    display: block;
+    padding: 5px 0 0;
+    clear: both;
+    color: var(--color-fg-default);
+  }
+
+  & span.align-center {
+    display: block;
+    overflow: hidden;
+    clear: both;
+  }
+
+  & span.align-center > span {
+    display: block;
+    margin: 13px auto 0;
+    overflow: hidden;
+    text-align: center;
+  }
+
+  & span.align-center span img {
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  & span.align-right {
+    display: block;
+    overflow: hidden;
+    clear: both;
+  }
+
+  & span.align-right > span {
+    display: block;
+    margin: 13px 0 0;
+    overflow: hidden;
+    text-align: right;
+  }
+
+  & span.align-right span img {
+    margin: 0;
+    text-align: right;
+  }
+
+  & span.float-left {
+    display: block;
+    float: left;
+    margin-right: 13px;
+    overflow: hidden;
+  }
+
+  & span.float-left span {
+    margin: 13px 0 0;
+  }
+
+  & span.float-right {
+    display: block;
+    float: right;
+    margin-left: 13px;
+    overflow: hidden;
+  }
+
+  & span.float-right > span {
+    display: block;
+    margin: 13px auto 0;
+    overflow: hidden;
+    text-align: right;
+  }
+
+  & code,
+  & tt {
+    padding: 0.2em 0.4em;
+    margin: 0;
+    font-size: 85%;
+    white-space: break-spaces;
+    background-color: var(--color-bg-neutral-muted);
+    border-radius: 6px;
+  }
+
+  & code br,
+  & tt br {
+    display: none;
+  }
+
+  & del code {
+    text-decoration: inherit;
+  }
+
+  & samp {
+    font-size: 85%;
+  }
+
+  & pre code {
+    font-size: 100%;
+  }
+
+  & pre > code {
+    padding: 0;
+    margin: 0;
+    word-break: normal;
+    white-space: pre;
+    background: transparent;
+    border: 0;
+  }
+
+  & .highlight {
+    margin-bottom: var(--size-16);
+  }
+
+  & .highlight pre {
+    margin-bottom: 0;
+    word-break: normal;
+  }
+
+  & .highlight pre,
+  & pre {
+    padding: var(--size-16);
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
+    color: var(--color-fg-default);
+    background-color: var(--color-bg-muted);
+    border-radius: var(--size-border-radius);
+  }
+
+  & pre code,
+  & pre tt {
+    display: inline;
+    max-width: auto;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    line-height: inherit;
+    word-wrap: normal;
+    background-color: transparent;
+    border: 0;
+  }
+
+  & .csv-data td,
+  & .csv-data th {
+    padding: 5px;
+    overflow: hidden;
+    font-size: 12px;
+    line-height: 1;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  & .csv-data .blob-num {
+    padding: 10px var(--size-8) 9px;
+    text-align: right;
+    background: var(--color-bg-default);
+    border: 0;
+  }
+
+  & .csv-data tr {
+    border-top: 0;
+  }
+
+  & .csv-data th {
+    font-weight: var(--text-weight-semibold);
+    background: var(--color-bg-muted);
+    border-top: 0;
+  }
+
+  & [data-footnote-ref]::before {
+    content: '[';
+  }
+
+  & [data-footnote-ref]::after {
+    content: ']';
+  }
+
+  & .footnotes {
+    font-size: 12px;
+    color: var(--color-fg-muted);
+    border-top: 1px solid var(--color-border-default);
+  }
+
+  & .footnotes ol {
+    padding-left: var(--size-16);
+  }
+
+  & .footnotes ol ul {
+    display: inline-block;
+    padding-left: var(--size-16);
+    margin-top: var(--size-16);
+  }
+
+  & .footnotes li {
+    position: relative;
+  }
+
+  & .footnotes li:target::before {
+    position: absolute;
+    top: calc(var(--size-8) * -1);
+    right: calc(var(--size-8) * -1);
+    bottom: calc(var(--size-8) * -1);
+    left: calc(var(--size-24) * -1);
+    pointer-events: none;
+    content: '';
+    border: 2px solid var(--color-border-accent-emphasis);
+    border-radius: var(--size-border-radius);
+  }
+
+  & .footnotes li:target {
+    color: var(--color-fg-default);
+  }
+
+  & .footnotes .data-footnote-backref g-emoji {
+    font-family: monospace;
+  }
+
+  & .pl-c {
+    color: var(--color-syntax-comment);
+  }
+
+  & .pl-c1,
+  & .pl-s .pl-v {
+    color: var(--color-syntax-constant);
+  }
+
+  & .pl-e,
+  & .pl-en {
+    color: var(--color-syntax-entity);
+  }
+
+  & .pl-smi,
+  & .pl-s .pl-s1 {
+    color: var(--color-syntax-storage-modifier-import);
+  }
+
+  & .pl-ent {
+    color: var(--color-syntax-entity-tag);
+  }
+
+  & .pl-k {
+    color: var(--color-syntax-keyword);
+  }
+
+  & .pl-s,
+  & .pl-pds,
+  & .pl-s .pl-pse .pl-s1,
+  & .pl-sr,
+  & .pl-sr .pl-cce,
+  & .pl-sr .pl-sre,
+  & .pl-sr .pl-sra {
+    color: var(--color-syntax-string);
+  }
+
+  & .pl-v,
+  & .pl-smw {
+    color: var(--color-syntax-variable);
+  }
+
+  & .pl-bu {
+    color: var(--color-syntax-brackethighlighter-unmatched);
+  }
+
+  & .pl-ii {
+    color: var(--color-syntax-invalid-illegal-text);
+    background-color: var(--color-syntax-invalid-illegal-bg);
+  }
+
+  & .pl-c2 {
+    color: var(--color-syntax-carriage-return-text);
+    background-color: var(--color-syntax-carriage-return-bg);
+  }
+
+  & .pl-sr .pl-cce {
+    font-weight: bold;
+    color: var(--color-syntax-string-regexp);
+  }
+
+  & .pl-ml {
+    color: var(--color-syntax-markup-list);
+  }
+
+  & .pl-mh,
+  & .pl-mh .pl-en,
+  & .pl-ms {
+    font-weight: bold;
+    color: var(--color-syntax-markup-heading);
+  }
+
+  & .pl-mi {
+    font-style: italic;
+    color: var(--color-syntax-markup-italic);
+  }
+
+  & .pl-mb {
+    font-weight: bold;
+    color: var(--color-syntax-markup-bold);
+  }
+
+  & .pl-md {
+    color: var(--color-syntax-markup-deleted-text);
+    background-color: var(--color-syntax-markup-deleted-bg);
+  }
+
+  & .pl-mi1 {
+    color: var(--color-syntax-markup-inserted-text);
+    background-color: var(--color-syntax-markup-inserted-bg);
+  }
+
+  & .pl-mc {
+    color: var(--color-syntax-markup-changed-text);
+    background-color: var(--color-syntax-markup-changed-bg);
+  }
+
+  & .pl-mi2 {
+    color: var(--color-syntax-markup-ignored-text);
+    background-color: var(--color-syntax-markup-ignored-bg);
+  }
+
+  & .pl-mdr {
+    font-weight: bold;
+    color: var(--color-syntax-meta-diff-range);
+  }
+
+  & .pl-ba {
+    color: var(--color-syntax-brackethighlighter-angle);
+  }
+
+  & .pl-sg {
+    color: var(--color-syntax-sublimelinter-gutter-mark);
+  }
+
+  & .pl-corl {
+    text-decoration: underline;
+    color: var(--color-syntax-constant-other-reference-link);
+  }
+
+  & [role='button']:focus:not(:focus-visible),
+  & [role='tabpanel'][tabindex='0']:focus:not(:focus-visible),
+  & button:focus:not(:focus-visible),
+  & summary:focus:not(:focus-visible),
+  & a:focus:not(:focus-visible) {
+    outline: none;
+    box-shadow: none;
+  }
+
+  & [tabindex='0']:focus:not(:focus-visible),
+  & details-dialog:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  & g-emoji {
+    display: inline-block;
+    min-width: 1ch;
+    font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-size: 1em;
+    font-style: normal !important;
+    font-weight: var(--text-weight-normal);
+    line-height: 1;
+    vertical-align: -0.075em;
+  }
+
+  & g-emoji img {
+    width: 1em;
+    height: 1em;
+  }
+
+  & .task-list-item {
+    list-style-type: none;
+  }
+
+  & .task-list-item label {
+    font-weight: var(--text-weight-normal);
+  }
+
+  & .task-list-item.enabled label {
+    cursor: pointer;
+  }
+
+  & .task-list-item + .task-list-item {
+    margin-top: var(--size-4);
+  }
+
+  & .task-list-item .handle {
+    display: none;
+  }
+
+  & .task-list-item-checkbox {
+    margin: 0 0.2em 0.25em -1.4em;
+    vertical-align: middle;
+  }
+
+  & ul:dir(rtl) .task-list-item-checkbox {
+    margin: 0 -1.6em 0.25em 0.2em;
+  }
+
+  & ol:dir(rtl) .task-list-item-checkbox {
+    margin: 0 -1.6em 0.25em 0.2em;
+  }
+
+  & .contains-task-list:hover .task-list-item-convert-container,
+  & .contains-task-list:focus-within .task-list-item-convert-container {
+    display: block;
+    width: auto;
+    height: 24px;
+    overflow: visible;
+    clip: auto;
+  }
+
+  & ::-webkit-calendar-picker-indicator {
+    filter: invert(50%);
+  }
+
+  & .markdown-alert {
+    padding: var(--size-8) var(--size-16);
+    margin-bottom: var(--size-16);
+    color: inherit;
+    border-left: 0.25em solid var(--color-border-default);
+  }
+
+  & .markdown-alert > :first-child {
+    margin-top: 0;
+  }
+
+  & .markdown-alert > :last-child {
+    margin-bottom: 0;
+  }
+
+  & .markdown-alert .markdown-alert-title {
+    display: flex;
+    font-weight: var(--text-weight-medium);
+    align-items: center;
+    line-height: 1;
+  }
+
+  & .markdown-alert.markdown-alert-note {
+    border-left-color: var(--color-border-accent-emphasis);
+  }
+
+  & .markdown-alert.markdown-alert-note .markdown-alert-title {
+    color: var(--color-fg-accent);
+  }
+
+  & .markdown-alert.markdown-alert-important {
+    border-left-color: var(--color-border-done-emphasis);
+  }
+
+  & .markdown-alert.markdown-alert-important .markdown-alert-title {
+    color: var(--color-fg-done);
+  }
+
+  & .markdown-alert.markdown-alert-warning {
+    border-left-color: var(--color-border-attention-emphasis);
+  }
+
+  & .markdown-alert.markdown-alert-warning .markdown-alert-title {
+    color: var(--color-fg-attention);
+  }
+
+  & .markdown-alert.markdown-alert-tip {
+    border-left-color: var(--color-border-success-emphasis);
+  }
+
+  & .markdown-alert.markdown-alert-tip .markdown-alert-title {
+    color: var(--color-fg-success);
+  }
+
+  & .markdown-alert.markdown-alert-caution {
+    border-left-color: var(--color-border-danger-emphasis);
+  }
+
+  & .markdown-alert.markdown-alert-caution .markdown-alert-title {
+    color: var(--color-fg-danger);
+  }
+
+  & > *:first-child > .heading-element:first-child {
+    margin-top: 0 !important;
+  }
+
+  /* custom properties: used by `rehype-github-color` */
+
+  & .d-inline-block {
+    display: inline-block !important;
+  }
+
+  & .ml-1 {
+    margin-left: 4px !important;
+  }
+
+  & .color-border-subtle {
+    border-color: var(--color-border-subtle) !important;
+  }
+
+  & .circle {
+    border-radius: 50% !important;
+  }
+
+  & .border {
+    border: 1px solid var(--color-border-default) !important;
+  }
 }

--- a/apps/blog/src/styles/normalize.css
+++ b/apps/blog/src/styles/normalize.css
@@ -1,4 +1,3 @@
-/* stylelint-disable */
 /*! modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
 
 /*
@@ -75,9 +74,9 @@ Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
 
 sub,
 sup {
+  position: relative;
   font-size: 75%;
   line-height: 0;
-  position: relative;
   vertical-align: baseline;
 }
 
@@ -108,8 +107,8 @@ Forms
 */
 
 /**
-1. Change the font styles in all browsers.
-2. Remove the margin in Firefox and Safari.
+1. Remove the margin in Firefox and Safari.
+2. Change the font styles in all browsers.
 */
 
 button,
@@ -117,10 +116,10 @@ input,
 optgroup,
 select,
 textarea {
-  font-family: inherit; /* 1 */
-  font-size: 100%; /* 1 */
-  line-height: 1.15; /* 1 */
-  margin: 0; /* 2 */
+  margin: 0; /* 1 */
+  font-family: inherit; /* 2 */
+  font-size: 100%; /* 2 */
+  line-height: 1.15; /* 2 */
 }
 
 /**
@@ -178,13 +177,13 @@ Remove the inner padding in Chrome and Safari on macOS.
 }
 
 /**
-1. Correct the inability to style clickable types in iOS and Safari.
-2. Change font properties to 'inherit' in Safari.
+1. Change font properties to 'inherit' in Safari.
+2. Correct the inability to style clickable types in iOS and Safari.
 */
 
 ::-webkit-file-upload-button {
-  -webkit-appearance: button; /* 1 */
-  font: inherit; /* 2 */
+  font: inherit; /* 1 */
+  -webkit-appearance: button; /* 2 */
 }
 
 /*

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -3,7 +3,6 @@ export default {
   extends: ['stylelint-config-standard', 'stylelint-config-recess-order'],
   ignoreFiles: ['archives/**', 'coverage/**'],
   rules: {
-    'declaration-empty-line-before': null,
     'import-notation': 'string',
     // Enforce specific media feature breakpoints for consistency
     'media-feature-range-notation': 'context',
@@ -25,6 +24,7 @@ export default {
     {
       files: ['**/markdown.css', '**/normalize.css'],
       rules: {
+        'declaration-empty-line-before': null,
         'property-no-vendor-prefix': null,
       },
     },

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -3,6 +3,8 @@ export default {
   extends: ['stylelint-config-standard', 'stylelint-config-recess-order'],
   ignoreFiles: ['archives/**', 'coverage/**'],
   rules: {
+    'declaration-empty-line-before': null,
+    'property-no-vendor-prefix': null,
     'import-notation': 'string',
     // Enforce specific media feature breakpoints for consistency
     'media-feature-range-notation': 'context',

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -4,7 +4,6 @@ export default {
   ignoreFiles: ['archives/**', 'coverage/**'],
   rules: {
     'declaration-empty-line-before': null,
-    'property-no-vendor-prefix': null,
     'import-notation': 'string',
     // Enforce specific media feature breakpoints for consistency
     'media-feature-range-notation': 'context',
@@ -22,4 +21,12 @@ export default {
       ],
     },
   },
+  overrides: [
+    {
+      files: ['**/markdown.css', '**/normalize.css'],
+      rules: {
+        'property-no-vendor-prefix': null,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- Refactor repeated `markdown.css` selector groups to use native CSS nesting.
- Keep markdown rendering styles and cascade order unchanged while reducing selector duplication.

## Testing
- `npm run build:pkg` passed.
- `npm run test` passed after package build completed.
- `npm run lint:stylelint` passed.
- `npm run lint:prettier` passed.
- `npm run lint:markdownlint` passed.
- `npm run lint:editorconfig` passed.
- `npm run lint:eslint` passed with existing warnings.
- `npm run build:a:b` failed during `/_not-found` prerender because `auth` was undefined.
- `npm run lint` failed because `lint:clangformat` requires `xargs` in this Windows environment.