### PR TITLE
chore(*): fix `clang-format` script compatible with Windows environments

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -4,7 +4,7 @@ export default {
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
   '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint --fix',
-  '*.css': 'npx stylelint',
+  '*.css': 'npx stylelint --fix',
   '*.md': 'npx markdownlint --fix',
-  '*.{h,c,cpp}': 'npx clang-format -n -Werror',
+  '*.{h,c,cpp}': 'npx clang-format -i',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@types/node": "^20.19.39",
         "@vitest/coverage-v8": "^4.1.2",
-        "clang-format-git": "^3.0.2",
+        "clang-format-node": "^3.0.2",
         "editorconfig-checker": "^6.1.1",
         "eslint": "^9.39.4",
         "eslint-config-bananass": "^0.6.1",
@@ -3660,27 +3660,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/clang-format-git": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/clang-format-git/-/clang-format-git-3.0.2.tgz",
-      "integrity": "sha512-ba7AlzGmcs3ZJAo5+BSvP4jQ5o0xIMMk5EthSkCIRwHyuJZ3qrFFgrDbRGLRkN3nFwitvXQ4D8/Bw4PZXF/4vg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "clang-format-node": "^3.0.2"
-      },
-      "bin": {
-        "clang-format-git": "build/cli.js",
-        "git-clang-format": "build/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lumirlumir"
       }
     },
     "node_modules/clang-format-node": {

--- a/package.json
+++ b/package.json
@@ -37,19 +37,19 @@
     "fix:stylelint": "npx stylelint --fix **/*.css",
     "fix:prettier": "npx prettier . --write --ignore-unknown",
     "fix:markdownlint": "npx markdownlint **/*.md --fix",
-    "fix:clangformat": "find . -name '*.h' -o -name '*.c' -o -name '*.cpp' -print0 | xargs -0 npx clang-format -i",
+    "fix:clangformat": "node scripts/clang-format.js --fix",
     "lint": "npm-run-all -c -l -p lint:*",
     "lint:eslint": "npx eslint",
     "lint:stylelint": "npx stylelint **/*.css",
     "lint:prettier": "npx prettier . --check --ignore-unknown",
     "lint:editorconfig": "npx editorconfig-checker -config .editorconfig-checker.json",
     "lint:markdownlint": "npx markdownlint **/*.md",
-    "lint:clangformat": "find . -name '*.h' -o -name '*.c' -o -name '*.cpp' -print0 | xargs -0 npx clang-format -n -Werror"
+    "lint:clangformat": "node scripts/clang-format.js"
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
     "@vitest/coverage-v8": "^4.1.2",
-    "clang-format-git": "^3.0.2",
+    "clang-format-node": "^3.0.2",
     "editorconfig-checker": "^6.1.1",
     "eslint": "^9.39.4",
     "eslint-config-bananass": "^0.6.1",

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -17,9 +17,14 @@ const paths = [...appsPaths, ...archivesPaths].filter(path =>
   /\.(?:c|cpp|h)$/i.test(path),
 );
 
+if (paths.length === 0) {
+  console.log('No files found to format'); // eslint-disable-line no-console -- logging
+  process.exit(0);
+}
+
 const { status } = spawnSync(clangFormatPath, [...args, ...paths], { stdio: 'inherit' });
 
 if (status !== 0) {
-  console.error('clang-format failed with status code', status); // eslint-disable-line no-console -- log error
+  console.error('clang-format failed with status code', status); // eslint-disable-line no-console -- logging
   process.exit(status);
 }

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { clangFormatPath } from 'clang-format-node'; // eslint-disable-line import/no-extraneous-dependencies
+
+const args = process.argv[2] === '--fix' ? ['-i'] : ['-n', '-Werror'];
+
+const apps = join(import.meta.dirname, '..', 'apps', 'blog', 'src');
+const archives = join(import.meta.dirname, '..', 'archives');
+
+const appsPaths = readdirSync(apps, { recursive: true }).map(path => join(apps, path));
+const archivesPaths = readdirSync(archives, { recursive: true }).map(path =>
+  join(archives, path),
+);
+
+const paths = [...appsPaths, ...archivesPaths].filter(path =>
+  /\.(?:c|cpp|h)$/i.test(path),
+);
+
+spawnSync(clangFormatPath, [...args, ...paths], { stdio: 'inherit' });

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -17,4 +17,9 @@ const paths = [...appsPaths, ...archivesPaths].filter(path =>
   /\.(?:c|cpp|h)$/i.test(path),
 );
 
-spawnSync(clangFormatPath, [...args, ...paths], { stdio: 'inherit' });
+const { status } = spawnSync(clangFormatPath, [...args, ...paths], { stdio: 'inherit' });
+
+if (status !== 0) {
+  console.error('clang-format failed with status code', status); // eslint-disable-line no-console -- log error
+  process.exit(status);
+}

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -22,7 +22,14 @@ if (paths.length === 0) {
   process.exit(0);
 }
 
-const { status } = spawnSync(clangFormatPath, [...args, ...paths], { stdio: 'inherit' });
+const { error, status } = spawnSync(clangFormatPath, [...args, ...paths], {
+  stdio: 'inherit',
+});
+
+if (error) {
+  console.error('Failed to run clang-format:', error); // eslint-disable-line no-console -- logging
+  process.exit(1);
+}
 
 if (status !== 0) {
   console.error('clang-format failed with status code', status); // eslint-disable-line no-console -- logging


### PR DESCRIPTION
This pull request updates the linting and formatting process for C, C++, and header files by switching from shell-based `clang-format` commands to a new Node.js script, and replaces the `clang-format-git` dependency with `clang-format-node`. The configuration for lint-staged and npm scripts is updated accordingly to use the new script and ensure automatic fixing where possible.

**Linting and formatting process improvements:**

* Added a new Node.js script `scripts/clang-format.js` that uses `clang-format-node` to format all `.c`, `.cpp`, and `.h` files in the `apps/blog/src` and `archives` directories, supporting both check and fix modes.
* Updated `package.json` scripts to use the new Node.js script for both `lint:clangformat` and `fix:clangformat`, replacing the previous `find`/`xargs` shell command.
* Updated the `lint-staged.config.mjs` configuration to run `clang-format` in fix mode (`-i`) instead of check mode (`-n -Werror`) for staged C/C++/header files, and enabled `--fix` for `stylelint`.

**Dependency changes:**

* Replaced the `clang-format-git` package with `clang-format-node` in `devDependencies` for better integration with Node.js scripts.