### PR TITLE
build(*): update Vercel configuration and add ignore command script

### DIFF
--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,6 +1,7 @@
 {
   "buildCommand": "npm run count-docs && npm run build:b --prefix ../..",
   "framework": "nextjs",
+  "ignoreCommand": "node ../../scripts/vercel-ignore-command.js",
   "installCommand": "npm ci --prefix ../..",
   "outputDirectory": ".next",
   "regions": ["icn1"]

--- a/apps/moing/tsconfig.json
+++ b/apps/moing/tsconfig.json
@@ -39,7 +39,7 @@
     },
     "module": "esnext",
     "moduleResolution": "bundler",
-    // "types": ["node", "react", "react-dom", "vite/client"],
+    "types": ["node", "react", "react-dom", "vite/client"],
 
     /* Emit */
     "declaration": true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,6 +73,13 @@ export default defineConfig([
       },
     },
   },
+  {
+    name: 'js/scripts',
+    files: ['scripts/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+    rules: {
+      'no-console': 'off', // Allow console statements in scripts.
+    },
+  },
 
   // md
   {

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -18,7 +18,7 @@ const paths = [...appsPaths, ...archivesPaths].filter(path =>
 );
 
 if (paths.length === 0) {
-  console.log('No files found to format'); // eslint-disable-line no-console -- logging
+  console.log('No files found to format');
   process.exit(0);
 }
 
@@ -27,11 +27,11 @@ const { error, status } = spawnSync(clangFormatPath, [...args, ...paths], {
 });
 
 if (error) {
-  console.error('Failed to run clang-format:', error); // eslint-disable-line no-console -- logging
+  console.error('Failed to run clang-format:', error);
   process.exit(1);
 }
 
 if (status !== 0) {
-  console.error('clang-format failed with status code', status); // eslint-disable-line no-console -- logging
+  console.error('clang-format failed with status code', status);
   process.exit(status);
 }

--- a/scripts/vercel-ignore-command.js
+++ b/scripts/vercel-ignore-command.js
@@ -1,0 +1,11 @@
+const author = process.env.VERCEL_GIT_COMMIT_AUTHOR_LOGIN;
+const branch = process.env.VERCEL_GIT_COMMIT_REF;
+
+// If the branch is `gh-pages`, ignore the build.
+if (branch === 'gh-pages') {
+  console.log(`🛑 Ignoring build for this branch (author: ${author}, branch: ${branch})`);
+  process.exit(0); // Return `0` to skip the build.
+}
+
+console.log(`✅ Proceeding with the build (author: ${author}, branch: ${branch})`);
+process.exit(1); // Return `1` to proceed with the build.


### PR DESCRIPTION
This pull request introduces improvements to the build process, linting configuration, and scripting practices. The most significant changes are the addition of a custom Vercel ignore command to skip builds for the `gh-pages` branch, an ESLint override for scripts, and minor code cleanup.

**Build process enhancements:**

* Added a custom ignore command in `vercel.json` to run `scripts/vercel-ignore-command.js`, which skips Vercel builds when the branch is `gh-pages` to avoid unnecessary deployments. [[1]](diffhunk://#diff-3a4bc04fd7005d05a56d9bfeec3eb4e2d15ef6f972d905aa46e7dfefe4ca4445R4) [[2]](diffhunk://#diff-9cbdf0f220ebe9d719bb4c66ec710bfd6c2bb7cf24814cffba3c6893ec8a6abcR1-R11)

**Linting configuration:**

* Updated `eslint.config.mjs` to allow `console` statements in all files under the `scripts/` directory, making script development and debugging easier.

**Script cleanup:**

* Removed inline ESLint disable comments for `console` statements in `scripts/clang-format.js`, as these are now allowed by the updated ESLint configuration. [[1]](diffhunk://#diff-5b09cfe7c60a67217c63b52c94df5a6f43988206d1b5089ead59af17b2c2d298L21-R21) [[2]](diffhunk://#diff-5b09cfe7c60a67217c63b52c94df5a6f43988206d1b5089ead59af17b2c2d298L30-R35)