### PR TITLE
build(moing): update build script and enhance TypeScript configuration

### DIFF
--- a/apps/moing/package.json
+++ b/apps/moing/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "npm run test:types && vite build",
     "start": "vite preview",
     "test": "npm run test:types && npm run test:unit",
     "test:types": "tsc",

--- a/apps/moing/src/components/button.tsx
+++ b/apps/moing/src/components/button.tsx
@@ -34,7 +34,13 @@ interface Props {
 // Export
 // --------------------------------------------------------------------------------
 
-export default function Button({ type, icon, scenario, onClick, hoverEffect }: Props) {
+export default function Button({
+  type,
+  icon,
+  scenario,
+  onClick,
+  hoverEffect = false,
+}: Props) {
   const { visibility, clickability } = scenario.getSectionObj()[type];
 
   return (

--- a/apps/moing/tsconfig.json
+++ b/apps/moing/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src/**/*.js",
     "src/**/*.mjs",
@@ -9,55 +10,35 @@
     "src/**/*.cts",
     "src/**/*.tsx"
   ],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.ts"],
+  "exclude": [
+    "src/**/*.test.js",
+    "src/**/*.test.mjs",
+    "src/**/*.test.cjs",
+    "src/**/*.test.jsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.mts",
+    "src/**/*.test.cts",
+    "src/**/*.test.tsx",
+    "**/fixtures/**"
+  ],
   "compilerOptions": {
     /* Type Checking */
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "alwaysStrict": true,
-    // "exactOptionalPropertyTypes": true,
-    "noFallthroughCasesInSwitch": true,
-    // "noImplicitAny": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noPropertyAccessFromIndexSignature": false, // Off: Prefer ESLint rule
-    "noUncheckedIndexedAccess": false, // Off: Too tight
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    // "strict": true,
-    "strictBindCallApply": true,
-    "strictBuiltinIteratorReturn": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    // "strictPropertyInitialization": true,
-    "useUnknownInCatchVariables": true,
+    "noImplicitAny": false, // TODO: Enable this in the future for better type safety.
 
     /* Modules */
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": ["./src/*"] // Map the '@' alias to the 'src' directory.
     },
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "types": ["node", "react", "react-dom", "vite/client"],
+    "types": ["@lumir/types/global", "node", "react", "react-dom", "vite/client"],
 
     /* Emit */
-    "declaration": true,
-    "emitDeclarationOnly": true,
     "noEmit": true,
-    "outDir": "build",
-
-    /* JavaScript Support */
-    "allowJs": true,
-    "checkJs": true,
-
-    /* Interop Constraints */
-    "allowSyntheticDefaultImports": true,
 
     /* Language and Environment */
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
 
     /* Completeness */
     "skipLibCheck": true


### PR DESCRIPTION
This pull request introduces several improvements to the build process, TypeScript configuration, and the default behavior of the `Button` component in the `apps/moing` project. The most significant changes include enforcing type checking before builds, refining TypeScript project settings for stricter and more consistent type safety, and improving the usability of the `Button` component by providing a default value for the `hoverEffect` prop.

**Build process improvements:**

* The `build` script in `package.json` now runs type checks (`test:types`) before building, ensuring type errors are caught early.

**TypeScript configuration updates:**

* The `tsconfig.json` now extends from a shared base config and includes additional type definitions (`@lumir/types/global`), promoting consistency across projects. [[1]](diffhunk://#diff-ad5ae4e30879cb32996f605a6cd4da83784338d345741157fc7507b576ef457eR2) [[2]](diffhunk://#diff-ad5ae4e30879cb32996f605a6cd4da83784338d345741157fc7507b576ef457eL12-R41)
* The list of excluded files in `tsconfig.json` has been expanded to ignore more test and fixture files, reducing noise in type checking.
* Several strict TypeScript options were removed or commented out, and `noImplicitAny` is now explicitly set to `false` (with a note to enable it later), balancing type safety with development flexibility.

**Component usability:**

* The `Button` component now defaults the `hoverEffect` prop to `false`, making it easier to use without specifying this prop every time.