### PR TITLE
ci(*): use latest GitHub Actions workflow setup for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/deploy.yml'
       - 'apps/moing/**'
       - 'packages/**'
       - 'package-lock.json'
@@ -12,17 +13,22 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/deploy.yml'
       - 'apps/moing/**'
       - 'packages/**'
       - 'package-lock.json'
       - 'package.json'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+
+    env:
+      BACKEND_PORT: ${{ secrets.BACKEND_PORT }}
+      BACKEND_IP: ${{ secrets.BACKEND_IP }}
 
     steps:
       - name: Set up checkout
@@ -37,17 +43,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set up environment variables
-        run: |
-          echo "BACKEND_PORT=${{ secrets.BACKEND_PORT }}" >> apps/moing/.env
-          echo "BACKEND_IP=${{ secrets.BACKEND_IP }}" >> apps/moing/.env
-
       - name: Build
         run: npm run build:m
 
-      - name: Deployment
+      - name: Upload static files as artifact
         if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./apps/moing/build
+          path: ./apps/moing/build
+
+  deploy:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    if: github.ref == 'refs/heads/main'
+
+    permissions:
+      id-token: write
+      pages: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      BACKEND_PORT: ${{ secrets.BACKEND_PORT }}
-      BACKEND_IP: ${{ secrets.BACKEND_IP }}
-
     steps:
       - name: Set up checkout
         uses: actions/checkout@v6
@@ -45,6 +41,9 @@ jobs:
 
       - name: Build
         run: npm run build:m
+        env:
+          BACKEND_PORT: ${{ vars.BACKEND_PORT }}
+          BACKEND_IP: ${{ vars.BACKEND_IP }}
 
       - name: Upload static files as artifact
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deployment, introducing a clearer separation between the build and deploy steps, improving artifact handling, and refining permissions for better security. The workflow now builds the project, uploads the build output as an artifact, and then deploys it to GitHub Pages using updated actions.

**Workflow structure and deployment process:**

* Split the deployment job into two separate jobs: `build` (which builds the project and uploads the build output as an artifact) and `deploy` (which depends on the build job and deploys the artifact to GitHub Pages using `actions/deploy-pages@v5`). This separation improves clarity and reliability of the deployment pipeline.

**Artifact and deployment action updates:**

* Replaced the previous deployment step using `peaceiris/actions-gh-pages@v4` with the recommended `actions/upload-pages-artifact@v5` and `actions/deploy-pages@v5` for uploading and deploying static files, aligning with GitHub's latest best practices for Pages deployments.

**Workflow triggers and paths:**

* Updated the workflow triggers to include changes to `.github/workflows/deploy.yml` in both `push` and `pull_request` events, ensuring the workflow runs when the workflow file itself is modified. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R7) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R16-R32)

**Permissions and environment variables:**

* Changed workflow permissions from `contents: write` to `contents: read` for the build job, and set the appropriate `id-token` and `pages` permissions for the deploy job, enhancing security. Also, moved environment variable setup to the `env` block of the build job.

Let me know if you want to walk through any part of the new workflow or discuss how these changes affect our deployment process!