### PR TITLE
fix(blog): correct GitHub repository name format

### DIFF
--- a/apps/blog/src/constants.ts
+++ b/apps/blog/src/constants.ts
@@ -12,7 +12,7 @@ export const WEBSITE_URL = `https://${WEBSITE_NAME}`;
 
 // GitHub Repository, Ref: https://docs.github.com/en/rest/repos/repos
 export const GITHUB_REPO_OWNER = 'lumirlumir';
-export const GITHUB_REPO_NAME = `${WEBSITE_NAME}`;
+export const GITHUB_REPO_NAME = WEBSITE_NAME;
 export const GITHUB_REPO_FULL_NAME = `${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}`;
 
 // Google

--- a/apps/blog/src/constants.ts
+++ b/apps/blog/src/constants.ts
@@ -12,7 +12,7 @@ export const WEBSITE_URL = `https://${WEBSITE_NAME}`;
 
 // GitHub Repository, Ref: https://docs.github.com/en/rest/repos/repos
 export const GITHUB_REPO_OWNER = 'lumirlumir';
-export const GITHUB_REPO_NAME = `web-${WEBSITE_NAME}`;
+export const GITHUB_REPO_NAME = `${WEBSITE_NAME}`;
 export const GITHUB_REPO_FULL_NAME = `${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}`;
 
 // Google


### PR DESCRIPTION
This pull request makes a small change to the `apps/blog/src/constants.ts` file, updating the value of `GITHUB_REPO_NAME` to use only the `WEBSITE_NAME` variable, instead of prefixing it with `'web-'`.