### PR TITLE
build(*): (perf) use TypeScript 7 beta

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,9 +6,9 @@
     "node": "^20.19.6"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsgo",
     "dev": "node --env-file=.env --watch ./src/server.js",
-    "test": "tsc"
+    "test": "tsgo"
   },
   "dependencies": {
     "openai": "^6.34.0"

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -10,7 +10,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "test": "npm run test:types && npm run test:unit",
-    "test:types": "next typegen && tsc",
+    "test:types": "next typegen && tsgo",
     "test:unit": "vitest run",
     "count-docs": "ls -R src/posts/docs | grep .md | wc -l"
   },

--- a/apps/moing/package.json
+++ b/apps/moing/package.json
@@ -10,7 +10,7 @@
     "build": "npm run test:types && vite build",
     "start": "vite preview",
     "test": "npm run test:types && npm run test:unit",
-    "test:types": "tsc",
+    "test:types": "tsgo",
     "test:unit": "node --test"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@types/node": "^20.19.39",
+        "@typescript/native-preview": "^7.0.0-dev.20260424.2",
         "@vitest/coverage-v8": "^4.1.4",
         "clang-format-node": "^3.0.3",
         "editorconfig-checker": "^6.1.1",
@@ -2805,6 +2806,147 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-NhxfO8WQHrv7SAqOVaY1NBKkWO5dKFoakvqBKiUDBiY27atZfoDkMQpOXyoPfuW3COVxHZKzm0vAZuiA7kF73g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260424.2"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-Fk0pY4FaPpmYfmLG0xowocG3Q+Bo78WkTg33+OjctzkM1w8hp/d6jo3m4ROCFYBiH2EwY5RZ7cECX6el5FVPtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-/37FW1CUcUT51oGIrWyC92+pstzW+v4l9alSyLSxY62crJt+GiOff7wIau34xrfEx7VE2gRpUGs9ld25Pr9VHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-xNBtutVYBKeA1iJan2La98hEt5e8HxSlLMicIaq7XwWb6lok7a3qppnk7gFrTMx3JBgFXlN/7cafV4Nxwq8DJQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-/XoSdXZEkz5TGimjAXhC7SwbqceOgaGsFP6ChmcDPsdsSZUtFP+7jh+WnDWyACcGu289VTNmfKDoG9szFiZ9TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-pJzvZ6uaKCBNphipzAgxvNAbmj++EIAO1CpUZsUoL9GVpGZ0whyvFXIDqdlUnKcOdQMiDYB+HlKc6ahiH0OKkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-4aHRCE1w77xQOn013E5/gkYkNQwNYvZfE8YR5cTeHimFZ5MB2kmoB0iLABaKXYbsMNPXixN5xeu8HdabrAuhag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-mVQXT6/F8d51zKOBmaWdUcT0z3WZ6kAlv/tGLTixM6HKlc8lIqzVnTuTqv7ixKcle18M+r0dn951uL6Bhb3Fjg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dev:pg": "npm run dev -w playground",
     "build:b": "npm-run-all -c -l -p build:pkg:* && npm run build -w apps/blog",
     "build:m": "npm-run-all -c -l -p build:pkg:* && npm run build -w apps/moing",
+    "build:a:a": "npm run build -w apps/api",
     "build:a:b": "npm run build -w apps/blog",
     "build:a:m": "npm run build -w apps/moing",
     "build:pkg": "npm-run-all -c -l -p build:pkg:*",
@@ -63,6 +64,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
+    "@typescript/native-preview": "^7.0.0-dev.20260424.2",
     "@vitest/coverage-v8": "^4.1.4",
     "clang-format-node": "^3.0.3",
     "editorconfig-checker": "^6.1.1",

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -32,8 +32,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsgo",
+    "dev": "tsgo --watch",
     "test": "vitest run"
   },
   "peerDependencies": {

--- a/packages/rehype-plugins/package.json
+++ b/packages/rehype-plugins/package.json
@@ -18,8 +18,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsgo",
+    "dev": "tsgo --watch",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -18,8 +18,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsgo",
+    "dev": "tsgo --watch",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,6 +17,6 @@
     }
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsgo"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,8 @@
     }
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "tsgo",
+    "dev": "tsgo --watch",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request updates the build and type-check scripts across multiple packages to use `tsgo` instead of `tsc`, aligning the toolchain with the `@typescript/native-preview` package. Additionally, it introduces a new build script for the API package at the root level and adds the latest TypeScript native preview as a dev dependency.

**Toolchain migration to `tsgo`:**

* Replaced `tsc` with `tsgo` in the `build`, `dev`, and type-check scripts for `apps/api`, `apps/blog`, `apps/moing`, `packages/react-kit`, `packages/rehype-plugins`, `packages/remark-plugins`, `packages/types`, and `packages/utils` (`[[1]](diffhunk://#diff-2c40985d6d91eed8ae85ec1c8e754a85984ee32e156a600d2b7a467423d7e338L9-R11)`, `[[2]](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171L13-R13)`, `[[3]](diffhunk://#diff-47a797035ad24ee8eb3ef853deaeac5042d7e795ac49cbe6c9549ce1a94449faL13-R13)`, `[[4]](diffhunk://#diff-c9d93c557e255ebd8eea63661f6200a9c05a3abdc4820f6074e7e53ba61a760fL35-R36)`, `[[5]](diffhunk://#diff-f01544832f113658f9724ce7873615af2f7a80667b6ef01ca18845a057ee33c8L21-R22)`, `[[6]](diffhunk://#diff-e9a0588481e249aa226c5ae4f39f9d204991d7516d73961ddc1966dd066527d7L21-R22)`, `[[7]](diffhunk://#diff-d20e06952213067104fa5b4a1976cbc97cd55806ac11d137d92c905d63c15054L20-R20)`, `[[8]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053L21-R22)`).

**Monorepo build process improvements:**

* Added a new root-level script `build:a:a` to build the `apps/api` package (`[package.jsonR40](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R40)`).

**Dependency updates:**

* Added `@typescript/native-preview@^7.0.0-dev.20260424.2` as a dev dependency in the root `package.json` to support the new toolchain (`[package.jsonR67](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R67)`).