### PR TITLE
chore(*): remove unnecessary packages from `types` field

### DIFF
--- a/packages/rehype-plugins/tsconfig.json
+++ b/packages/rehype-plugins/tsconfig.json
@@ -24,7 +24,7 @@
   "compilerOptions": {
     /* Modules */
     "rootDir": "./src",
-    "types": ["hast"],
+    "types": [],
 
     /* Emit */
     "emitDeclarationOnly": false,

--- a/packages/remark-plugins/tsconfig.json
+++ b/packages/remark-plugins/tsconfig.json
@@ -24,7 +24,7 @@
   "compilerOptions": {
     /* Modules */
     "rootDir": "./src",
-    "types": ["mdast"],
+    "types": [],
 
     /* Emit */
     "emitDeclarationOnly": false,


### PR DESCRIPTION
This pull request makes a minor update to the TypeScript configuration for both the `rehype-plugins` and `remark-plugins` packages. The change removes explicit type definitions for `hast` and `mdast` from their respective `tsconfig.json` files, which may help reduce unnecessary type dependencies if they are not used directly.

- TypeScript configuration updates:
  * [`packages/rehype-plugins/tsconfig.json`](diffhunk://#diff-9a240e06144ab33c98ef340026183a860d49ebdaa40f61c7fbaecd15a5436a3eL27-R27): Removed `hast` from the `types` array.
  * [`packages/remark-plugins/tsconfig.json`](diffhunk://#diff-9a240e06144ab33c98ef340026183a860d49ebdaa40f61c7fbaecd15a5436a3eL27-R27): Removed `mdast` from the `types` array.