### PR TITLE
refactor(blog): use lazy loading and caching for `markdown-collection`

### DIFF
--- a/apps/blog/src/app/categories/[category]/page.tsx
+++ b/apps/blog/src/app/categories/[category]/page.tsx
@@ -12,11 +12,14 @@ import Loading from '@/components/common/loading';
 import { type CategoryKey } from '@/data/category';
 import { type SortableFrontmatterKey } from '@/data/frontmatter';
 import { type SortKey } from '@/data/sort';
-import {
-  listNonEmptyCategoryKeys,
-  markdownCollectionCategory,
-} from '@/utils/markdown-collection';
+import createMarkdownCollection from '@/utils/markdown-collection';
 import { compareMarkdownDocument } from '@/utils/compare';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
 // Named Export
@@ -34,7 +37,7 @@ export const dynamicParams = false;
 export async function generateStaticParams(): Promise<
   Awaited<PageProps<'/categories/[category]'>['params']>[]
 > {
-  return listNonEmptyCategoryKeys(markdownCollectionCategory).map(category => ({
+  return markdownCollection.nonEmptyCategoryKeys.map(category => ({
     category,
   }));
 }
@@ -59,7 +62,7 @@ export default async function Page({
       key={normalizedSort + normalizedOrder}
       fallback={<Loading content="목록" />}
     >
-      {markdownCollectionCategory[category as CategoryKey]
+      {markdownCollection.category[category as CategoryKey]
         ?.toSorted(compareMarkdownDocument(normalizedSort, normalizedOrder))
         .map(vMarkdownFile => (
           <Content key={vMarkdownFile.slug} vMarkdownFile={vMarkdownFile} />

--- a/apps/blog/src/app/categories/[category]/page.tsx
+++ b/apps/blog/src/app/categories/[category]/page.tsx
@@ -64,8 +64,8 @@ export default async function Page({
     >
       {markdownCollection.category[category as CategoryKey]
         ?.toSorted(compareMarkdownDocument(normalizedSort, normalizedOrder))
-        .map(vMarkdownFile => (
-          <Content key={vMarkdownFile.slug} vMarkdownFile={vMarkdownFile} />
+        .map(vMarkdownFileMeta => (
+          <Content key={vMarkdownFileMeta.slug} vMarkdownFileMeta={vMarkdownFileMeta} />
         ))}
     </Suspense>
   );

--- a/apps/blog/src/app/categories/sitemap.ts
+++ b/apps/blog/src/app/categories/sitemap.ts
@@ -8,17 +8,20 @@
 
 import { type MetadataRoute } from 'next';
 import { WEBSITE_URL } from '@/constants';
-import {
-  listNonEmptyCategoryKeys,
-  markdownCollectionCategory,
-} from '@/utils/markdown-collection';
+import createMarkdownCollection from '@/utils/markdown-collection';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  return listNonEmptyCategoryKeys(markdownCollectionCategory).map(categoryKey => ({
+  return markdownCollection.nonEmptyCategoryKeys.map(categoryKey => ({
     url: `${WEBSITE_URL}/categories/${categoryKey}`,
     lastModified: new Date(),
     changeFrequency: 'weekly',

--- a/apps/blog/src/app/posts/[markdown]/page.tsx
+++ b/apps/blog/src/app/posts/[markdown]/page.tsx
@@ -33,7 +33,7 @@ export const dynamicParams = false;
 export async function generateStaticParams(): Promise<
   Awaited<PageProps<'/posts/[markdown]'>['params']>[]
 > {
-  return Object.values(markdownCollection.slug).map(({ slug }) => ({
+  return Object.keys(markdownCollection.slug).map(slug => ({
     markdown: slug,
   }));
 }
@@ -45,7 +45,9 @@ export async function generateMetadata({
   params,
 }: PageProps<'/posts/[markdown]'>): Promise<Metadata> {
   const { markdown } = await params;
-  const { title, description } = markdownCollection.slug[markdown].data;
+  const {
+    data: { title, description },
+  } = await markdownCollection.loadVMarkdownFile(markdown);
 
   return {
     title: await markdownToText(title),
@@ -62,7 +64,7 @@ export default async function Page({ params }: PageProps<'/posts/[markdown]'>) {
   const {
     content,
     data: { title, references },
-  } = markdownCollection.slug[markdown];
+  } = await markdownCollection.loadVMarkdownFile(markdown);
 
   return (
     <>

--- a/apps/blog/src/app/posts/[markdown]/page.tsx
+++ b/apps/blog/src/app/posts/[markdown]/page.tsx
@@ -7,9 +7,15 @@
 // --------------------------------------------------------------------------------
 
 import { type Metadata } from 'next';
-import { markdownCollectionSlug } from '@/utils/markdown-collection';
+import createMarkdownCollection from '@/utils/markdown-collection';
 import { markdownToHtml } from '@/utils/markdown-to-html';
 import { markdownToText } from '@/utils/markdown-to-text';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
 // Named Export
@@ -27,7 +33,7 @@ export const dynamicParams = false;
 export async function generateStaticParams(): Promise<
   Awaited<PageProps<'/posts/[markdown]'>['params']>[]
 > {
-  return Object.values(markdownCollectionSlug).map(({ slug }) => ({
+  return Object.values(markdownCollection.slug).map(({ slug }) => ({
     markdown: slug,
   }));
 }
@@ -39,7 +45,7 @@ export async function generateMetadata({
   params,
 }: PageProps<'/posts/[markdown]'>): Promise<Metadata> {
   const { markdown } = await params;
-  const { title, description } = markdownCollectionSlug[markdown].data;
+  const { title, description } = markdownCollection.slug[markdown].data;
 
   return {
     title: await markdownToText(title),
@@ -56,7 +62,7 @@ export default async function Page({ params }: PageProps<'/posts/[markdown]'>) {
   const {
     content,
     data: { title, references },
-  } = markdownCollectionSlug[markdown];
+  } = markdownCollection.slug[markdown];
 
   return (
     <>

--- a/apps/blog/src/app/posts/[markdown]/page.tsx
+++ b/apps/blog/src/app/posts/[markdown]/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({
   const { markdown } = await params;
   const {
     data: { title, description },
-  } = await markdownCollection.loadVMarkdownFile(markdown);
+  } = await markdownCollection.loadVMarkdownFileMeta(markdown);
 
   return {
     title: await markdownToText(title),

--- a/apps/blog/src/app/posts/sitemap.ts
+++ b/apps/blog/src/app/posts/sitemap.ts
@@ -8,14 +8,20 @@
 
 import { type MetadataRoute } from 'next';
 import { WEBSITE_URL } from '@/constants';
-import { markdownCollectionSlug } from '@/utils/markdown-collection';
+import createMarkdownCollection from '@/utils/markdown-collection';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  return Object.values(markdownCollectionSlug).map(({ slug, data: { updated } }) => ({
+  return Object.values(markdownCollection.slug).map(({ slug, data: { updated } }) => ({
     url: `${WEBSITE_URL}/posts/${slug}`,
     lastModified: updated,
     changeFrequency: 'monthly',

--- a/apps/blog/src/components/article/content.tsx
+++ b/apps/blog/src/components/article/content.tsx
@@ -11,7 +11,7 @@ import { type JSX, type PropsWithChildren } from 'react';
 import { cn } from '@lumir/utils';
 import { categoryMeta } from '@/data/category';
 import { frontmatterMeta } from '@/data/frontmatter';
-import { type VMarkdownFile } from '@/data/v-markdown-file';
+import { type VMarkdownFileMeta } from '@/data/v-markdown-file';
 import { markdownToHtmlLite } from '@/utils/markdown-to-html';
 import styles from './content.module.css';
 
@@ -41,12 +41,12 @@ function ContentBoxItem({ icon, text }: { icon: JSX.Element; text: string }) {
 // --------------------------------------------------------------------------------
 
 export default async function Content({
-  vMarkdownFile: {
+  vMarkdownFileMeta: {
     slug,
     data: { title, description, created, updated, categories },
   },
 }: {
-  vMarkdownFile: VMarkdownFile;
+  vMarkdownFileMeta: VMarkdownFileMeta;
 }) {
   return (
     <Link href={`/posts/${slug}`}>

--- a/apps/blog/src/components/aside/categories.tsx
+++ b/apps/blog/src/components/aside/categories.tsx
@@ -10,17 +10,14 @@ import Link from 'next/link';
 import { FaPen } from '@lumir/react-kit/svgs';
 import { cn } from '@lumir/utils';
 import { categoryMeta } from '@/data/category';
-import {
-  listNonEmptyCategoryKeys,
-  markdownCollectionCategory,
-} from '@/utils/markdown-collection';
+import createMarkdownCollection from '@/utils/markdown-collection';
 import styles from './categories.module.css';
 
 // --------------------------------------------------------------------------------
 // Helper
 // --------------------------------------------------------------------------------
 
-const categoryKeys = listNonEmptyCategoryKeys(markdownCollectionCategory);
+const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
 // Export
@@ -29,7 +26,7 @@ const categoryKeys = listNonEmptyCategoryKeys(markdownCollectionCategory);
 export default async function Categories() {
   return (
     <ul className={styles.categories}>
-      {categoryKeys
+      {markdownCollection.nonEmptyCategoryKeys
         .sort((a, b) => categoryMeta[a].order - categoryMeta[b].order) // Ascending.
         .map(categoryKey => {
           const {
@@ -47,7 +44,7 @@ export default async function Categories() {
                 <div className={styles['name-ko']}>{ko}</div>
                 <div className={cn(styles['count-docs'], 'custom-flex-center')}>
                   <span className="custom-flex-center">
-                    {markdownCollectionCategory[categoryKey]?.length}
+                    {markdownCollection.category[categoryKey]?.length}
                   </span>
                   <FaPen />
                 </div>

--- a/apps/blog/src/data/v-markdown-file.ts
+++ b/apps/blog/src/data/v-markdown-file.ts
@@ -13,9 +13,9 @@ import { type Frontmatter } from '@/data/frontmatter';
 // --------------------------------------------------------------------------------
 
 /**
- * Represents a Virtual Markdown file, containing the `slug` (excluding extension), `data` (frontmatter), and `content` of the Markdown document.
+ * Represents the metadata of a Virtual Markdown file, containing the `slug` (excluding extension) and `data` (frontmatter) of the Markdown document.
  */
-export interface VMarkdownFile {
+export interface VMarkdownFileMeta {
   /**
    * The slug of the Markdown file, excluding the leading directory path and extension (e.g., `example` for `./example.md`).
    */
@@ -25,7 +25,12 @@ export interface VMarkdownFile {
    * The data of the Markdown file, representing the frontmatter metadata defined in the `Frontmatter` interface.
    */
   readonly data: Frontmatter;
+}
 
+/**
+ * Represents a Virtual Markdown file, containing the `slug` (excluding extension), `data` (frontmatter), and `content` of the Markdown document.
+ */
+export interface VMarkdownFile extends VMarkdownFileMeta {
   /**
    * The content of the Markdown file, representing the raw Markdown text.
    */

--- a/apps/blog/src/utils/compare.ts
+++ b/apps/blog/src/utils/compare.ts
@@ -10,7 +10,7 @@
 
 import { type SortableFrontmatterKey } from '@/data/frontmatter';
 import { type SortKey } from '@/data/sort';
-import { type VMarkdownFile } from '@/data/v-markdown-file';
+import { type VMarkdownFileMeta } from '@/data/v-markdown-file';
 import { markdownToTextSync } from './markdown-to-text';
 
 // --------------------------------------------------------------------------------
@@ -23,7 +23,7 @@ import { markdownToTextSync } from './markdown-to-text';
 export function compareMarkdownDocument(sort: SortableFrontmatterKey, order: SortKey) {
   switch (sort) {
     case 'title': {
-      return (a: VMarkdownFile, b: VMarkdownFile) => {
+      return (a: VMarkdownFileMeta, b: VMarkdownFileMeta) => {
         const titleA = markdownToTextSync(a.data.title.toLowerCase()); // Case insensitive.
         const titleB = markdownToTextSync(b.data.title.toLowerCase()); // Case insensitive.
 
@@ -34,7 +34,7 @@ export function compareMarkdownDocument(sort: SortableFrontmatterKey, order: Sor
     }
     case 'created':
     case 'updated': {
-      return (a: VMarkdownFile, b: VMarkdownFile) => {
+      return (a: VMarkdownFileMeta, b: VMarkdownFileMeta) => {
         const dateA = new Date(a.data[sort]);
         const dateB = new Date(b.data[sort]);
 

--- a/apps/blog/src/utils/markdown-collection.test.ts
+++ b/apps/blog/src/utils/markdown-collection.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Test for `markdown-collection.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { assert, describe, it } from 'vitest';
+import createMarkdownCollection from './markdown-collection.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('markdown-collection', () => {
+  it('should reuse the same instance', () => {
+    const markdownCollection1 = createMarkdownCollection();
+    const markdownCollection2 = createMarkdownCollection();
+
+    assert.strictEqual(markdownCollection1, markdownCollection2);
+  });
+});

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -8,7 +8,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { frontmatter } from '@lumir/utils';
+import { frontmatter, frontmatterData } from '@lumir/utils';
 import { categoryKeys, type CategoryKey } from '@/data/category';
 import { type Frontmatter } from '@/data/frontmatter';
 import { type VMarkdownFileMeta, type VMarkdownFile } from '@/data/v-markdown-file';
@@ -101,7 +101,7 @@ class MarkdownCollection {
       }
 
       // If the Markdown file has not been processed, load and process it, then cache the result.
-      const { data } = frontmatter(context(key));
+      const { data } = frontmatterData(context(key));
       const sanitizedData = assertFrontmatter(data, slug);
 
       this.#map.set(slug, {
@@ -169,7 +169,7 @@ class MarkdownCollection {
       return cached;
     }
 
-    const { data } = frontmatter(
+    const { data } = frontmatterData(
       // Markdown files are imported as raw strings because of a setting in `next.config.js`.
       (await import(`../posts/docs/${slug}.md`)).default as string,
     );

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -63,6 +63,8 @@ class MarkdownCollection {
   // Private Property
   // ------------------------------------------------------------------------------
 
+  /** Webpack context for loading Markdown files */
+  #context: __WebpackModuleApi.RequireContext | null = null;
   /** Source of truth: used as a cache */
   #map: MarkdownCollectionMap = new Map();
   /** View: using `#map` as source of truth */
@@ -75,6 +77,25 @@ class MarkdownCollection {
   // ------------------------------------------------------------------------------
 
   /**
+   * Lazily creates a Webpack context for loading Markdown files.
+   */
+  #ensureContext(): __WebpackModuleApi.RequireContext {
+    if (this.#context) {
+      return this.#context;
+    }
+
+    const context = import.meta.webpackContext('../posts/docs', {
+      recursive: false,
+      regExp: /\.md$/,
+      mode: 'sync',
+    });
+
+    this.#context = context;
+
+    return context;
+  }
+
+  /**
    * Lazily loads and processes Markdown files from the specified directory, extracting their frontmatter.
    *
    * Performance Optimization:
@@ -84,11 +105,7 @@ class MarkdownCollection {
    *   Subsequent calls to this method will return the cached data, avoiding redundant processing.
    */
   #ensureMap(): Map<string, VMarkdownFileMeta> {
-    const context = import.meta.webpackContext('../posts/docs', {
-      recursive: false,
-      regExp: /\.md$/,
-      mode: 'sync',
-    });
+    const context = this.#ensureContext();
 
     for (const key of context.keys()) {
       const slug = key.replace(/^\.\//, '').replace(/\.md$/, '');

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -307,7 +307,8 @@ class MarkdownCollection {
 let markdownCollection: MarkdownCollection | null = null;
 
 /**
- * Creates a class that represents a collection of Markdown files, organized by `slug` and `category`.
+ * Creates and returns a singleton instance of the `MarkdownCollection` class
+ * that represents a collection of Markdown files, organized by `slug` and `category`.
  *
  * @example
  * ```ts

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -175,7 +175,7 @@ class MarkdownCollection {
     );
     const sanitizedData = assertFrontmatter(data, slug);
 
-    const vMarkdownFileMeta = {
+    const vMarkdownFileMeta: VMarkdownFileMeta = {
       slug,
       data: sanitizedData,
     };

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -17,159 +17,254 @@ import { isFrontmatter } from '@/utils/is-frontmatter';
 // Typedef
 // --------------------------------------------------------------------------------
 
-/**
- * A record mapping each slug to its corresponding metadata.
- *
- * @example
- * ```ts
- * {
- *   'example-post': {
- *     slug: 'example-post',
- *     data: {
- *       title: 'Example Post',
- *       description: 'This is an example post.',
- *       created: '2024-01-01',
- *       updated: '2024-01-02',
- *       categories: ['javascript', 'markdown'],
- *       references: ['https://example.com'],
- *     },
- *     content: '# Example Post\n\nThis is the content of the example post.',
- *   },
- *   // ...more
- * }
- * ```
- */
-export type MarkdownCollectionSlug = Record<string, VMarkdownFile>;
-
-/**
- * A record mapping each category key to an array of metadata for Markdown files that belong to that category.
- *
- * @example
- * ```ts
- * {
- *   javascript: [
- *     {
- *       slug: 'example-post',
- *       data: {
- *         title: 'Example Post',
- *         description: 'This is an example post.',
- *         created: '2024-01-01',
- *         updated: '2024-01-02',
- *         categories: ['javascript', 'markdown'],
- *         references: ['https://example.com'],
- *       },
- *       content: '# Example Post\n\nThis is the content of the example post.',
- *     },
- *     // ...more
- *   ],
- *   markdown: [
- *     {
- *       slug: 'example-post',
- *       data: {
- *         title: 'Example Post',
- *         description: 'This is an example post.',
- *         created: '2024-01-01',
- *         updated: '2024-01-02',
- *         categories: ['javascript', 'markdown'],
- *         references: ['https://example.com'],
- *       },
- *       content: '# Example Post\n\nThis is the content of the example post.',
- *     },
- *     // ...more
- *   ],
- *   // ...more
- * }
- * ```
- */
-export type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFile[]>;
+type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFile[]>;
+type MarkdownCollectionSlug = Record<string, VMarkdownFile>;
 
 // --------------------------------------------------------------------------------
-// Helper
+// Class
 // --------------------------------------------------------------------------------
 
 /**
- * A record mapping each slug to its corresponding metadata.
- *
- * @example
- * ```ts
- * {
- *   'example-post': {
- *     slug: 'example-post',
- *     data: {
- *       title: 'Example Post',
- *       description: 'This is an example post.',
- *       created: '2024-01-01',
- *       updated: '2024-01-02',
- *       categories: ['javascript', 'markdown'],
- *       references: ['https://example.com'],
- *     },
- *     content: '# Example Post\n\nThis is the content of the example post.',
- *   },
- *   // ...more
- * }
- * ```
+ * A class that represents a collection of Markdown files, organized by `slug` and `category`.
  */
-const markdownCollectionSlug: MarkdownCollectionSlug = {};
+class MarkdownCollection {
+  // ------------------------------------------------------------------------------
+  // Private Property
+  // ------------------------------------------------------------------------------
+
+  #vMarkdownFiles: VMarkdownFile[] | null = null;
+  #category: MarkdownCollectionCategory | null = null;
+  #slug: MarkdownCollectionSlug | null = null;
+
+  // ------------------------------------------------------------------------------
+  // Private Method
+  // ------------------------------------------------------------------------------
+
+  /**
+   * Lazily loads and processes Markdown files from the specified directory, extracting their frontmatter and content.
+   *
+   * Performance Optimization:
+   * - The method uses lazy loading to defer the loading and processing of Markdown files until they are actually needed.
+   *   This can improve the initial load time of the application, especially if there are many Markdown files.
+   * - Once the Markdown files are loaded and processed, they are cached in the `#vMarkdownFiles` property.
+   *   Subsequent calls to this method will return the cached data, avoiding redundant processing.
+   */
+  #ensureVMarkdownFiles(): VMarkdownFile[] {
+    // If the Markdown files have already been loaded, skip the loading process.
+    if (this.#vMarkdownFiles) {
+      return this.#vMarkdownFiles;
+    }
+
+    const context = import.meta.webpackContext('../posts/docs', {
+      recursive: false,
+      regExp: /\.md$/,
+      mode: 'sync',
+    });
+
+    const vMarkdownFiles: VMarkdownFile[] = context.keys().map(key => {
+      const { data, content } = frontmatter(context(key));
+
+      if (!isFrontmatter(data)) {
+        throw new Error(
+          `
+Invalid frontmatter in Markdown file: \`${key}\`
+
+Expected frontmatter format:
+  - \`title: string\`
+  - \`description: string\`
+  - \`created: string\`
+  - \`updated: string\`
+  - \`categories: CategoryKey[]\`
+  - \`references: string[]\`
+
+Received data: \`${JSON.stringify(data, null, 2)}\`
+`,
+        );
+      }
+
+      return {
+        slug: key.replace(/^\.\//, '').replace(/\.md$/, ''),
+        data,
+        content,
+      };
+    });
+
+    this.#vMarkdownFiles = vMarkdownFiles;
+
+    return vMarkdownFiles;
+  }
+
+  /**
+   * Lazily creates a mapping of category keys to arrays of Markdown file metadata.
+   */
+  #ensureCategory(): MarkdownCollectionCategory {
+    // If the category mapping has already been created, skip the creation process.
+    if (this.#category) {
+      return this.#category;
+    }
+
+    const markdownCollectionCategory = Object.fromEntries(
+      categoryKeys.map(categoryKey => [categoryKey, [] as VMarkdownFile[]]),
+    ) as MarkdownCollectionCategory;
+
+    this.#ensureVMarkdownFiles().forEach(vMarkdownFile => {
+      vMarkdownFile.data.categories.forEach(category => {
+        markdownCollectionCategory[category].push(vMarkdownFile);
+      });
+    });
+
+    this.#category = markdownCollectionCategory;
+
+    return markdownCollectionCategory;
+  }
+
+  /**
+   * Lazily creates a mapping of slugs to their corresponding Markdown file metadata.
+   */
+  #ensureSlug(): MarkdownCollectionSlug {
+    // If the slug mapping has already been created, skip the creation process.
+    if (this.#slug) {
+      return this.#slug;
+    }
+
+    const markdownCollectionSlug: MarkdownCollectionSlug = {};
+
+    this.#ensureVMarkdownFiles().forEach(vMarkdownFile => {
+      markdownCollectionSlug[vMarkdownFile.slug] = vMarkdownFile;
+    });
+
+    this.#slug = markdownCollectionSlug;
+
+    return markdownCollectionSlug;
+  }
+
+  // ------------------------------------------------------------------------------
+  // Getter and Setter
+  // ------------------------------------------------------------------------------
+
+  /**
+   * A record mapping each category key to an array of metadata for Markdown files that belong to that category.
+   *
+   * @example
+   * ```ts
+   * {
+   *   javascript: [
+   *     {
+   *       slug: 'example-post',
+   *       data: {
+   *         title: 'Example Post',
+   *         description: 'This is an example post.',
+   *         created: '2024-01-01',
+   *         updated: '2024-01-02',
+   *         categories: ['javascript', 'markdown'],
+   *       },
+   *       content: '# Example Post\n\nThis is the content of the example post.',
+   *     },
+   *     // ...more
+   *   ],
+   *   markdown: [
+   *     {
+   *       slug: 'example-post',
+   *       data: {
+   *         title: 'Example Post',
+   *         description: 'This is an example post.',
+   *         created: '2024-01-01',
+   *         updated: '2024-01-02',
+   *         categories: ['javascript', 'markdown'],
+   *       },
+   *       content: '# Example Post\n\nThis is the content of the example post.',
+   *     },
+   *     // ...more
+   *   ],
+   *   // ...more
+   * }
+   * ```
+   */
+  get category(): MarkdownCollectionCategory {
+    return this.#ensureCategory();
+  }
+
+  /**
+   * Returns a list of category keys that have at least one associated Markdown file in the collection.
+   *
+   * @example
+   * ```ts
+   * import createMarkdownCollection from '@/utils/markdown-collection';
+   *
+   * const markdownCollection = createMarkdownCollection();
+   * const nonEmptyCategories = markdownCollection.nonEmptyCategoryKeys;
+   * console.log(nonEmptyCategories); // Output: ['javascript', 'markdown']
+   * ```
+   */
+  get nonEmptyCategoryKeys(): CategoryKey[] {
+    return categoryKeys.filter(categoryKey => this.category[categoryKey].length > 0);
+  }
+
+  /**
+   * A record mapping each slug to its corresponding metadata.
+   *
+   * @example
+   * ```ts
+   * {
+   *   'example-post': {
+   *     slug: 'example-post',
+   *     data: {
+   *       title: 'Example Post',
+   *       description: 'This is an example post.',
+   *       created: '2024-01-01',
+   *       updated: '2024-01-02',
+   *       categories: ['javascript', 'markdown'],
+   *       references: ['https://example.com'],
+   *     },
+   *     content: '# Example Post\n\nThis is the content of the example post.',
+   *   },
+   *   // ...more
+   * }
+   * ```
+   */
+  get slug(): MarkdownCollectionSlug {
+    return this.#ensureSlug();
+  }
+}
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
 
 /**
- * A record mapping each category key to an array of metadata for Markdown files that belong to that category.
+ * A singleton instance of the `MarkdownCollection` class.
+ */
+let markdownCollection: MarkdownCollection | null = null;
+
+/**
+ * Creates a class that represents a collection of Markdown files, organized by `slug` and `category`.
  *
  * @example
  * ```ts
- * {
- *   javascript: [
- *     {
- *       slug: 'example-post',
- *       data: {
- *         title: 'Example Post',
- *         description: 'This is an example post.',
- *         created: '2024-01-01',
- *         updated: '2024-01-02',
- *         categories: ['javascript', 'markdown'],
- *       },
- *       content: '# Example Post\n\nThis is the content of the example post.',
- *     },
- *     // ...more
- *   ],
- *   markdown: [
- *     {
- *       slug: 'example-post',
- *       data: {
- *         title: 'Example Post',
- *         description: 'This is an example post.',
- *         created: '2024-01-01',
- *         updated: '2024-01-02',
- *         categories: ['javascript', 'markdown'],
- *       },
- *       content: '# Example Post\n\nThis is the content of the example post.',
- *     },
- *     // ...more
- *   ],
- *   // ...more
- * }
+ * import createMarkdownCollection from '@/utils/markdown-collection';
+ *
+ * const markdownCollection = createMarkdownCollection();
  * ```
  */
-const markdownCollectionCategory: MarkdownCollectionCategory = Object.fromEntries(
-  categoryKeys.map(categoryKey => [categoryKey, [] as VMarkdownFile[]]),
-) as MarkdownCollectionCategory;
+export default function createMarkdownCollection() {
+  markdownCollection ??= new MarkdownCollection();
+
+  return markdownCollection;
+}
 
 // --------------------------------------------------------------------------------
-// Load and Organize Markdown Files
+// TODO
 // --------------------------------------------------------------------------------
 
-const context = import.meta.webpackContext('../posts/docs', {
-  recursive: false,
-  regExp: /\.md$/,
-  mode: 'sync',
-});
-
-context.keys().forEach(key => {
-  const { data, content } = frontmatter(context(key));
+/*
+export async function loadMarkdownFile(slug: string): Promise<VMarkdownFile> {
+  const markdownFile = (await import(`../posts/docs/${slug}.md`)) as string;
+  const { data, content } = frontmatter(markdownFile);
 
   if (!isFrontmatter(data)) {
     throw new Error(
       `
-Invalid frontmatter in Markdown file: \`${key}\`
+Invalid frontmatter in Markdown file: \`${slug}.md\`
 
 Expected frontmatter format:
   - \`title: string\`
@@ -184,39 +279,10 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
     );
   }
 
-  const vMarkdownFile: VMarkdownFile = {
-    slug: key.replace(/^\.\//, '').replace(/\.md$/, ''),
+  return {
+    slug,
     data,
     content,
   };
-
-  // `markdownCollectionSlug`
-  markdownCollectionSlug[vMarkdownFile.slug] = vMarkdownFile;
-  // `markdownCollectionCategory`
-  data.categories.forEach(category => {
-    markdownCollectionCategory[category].push(vMarkdownFile);
-  });
-});
-
-// --------------------------------------------------------------------------------
-// Export
-// --------------------------------------------------------------------------------
-
-export { markdownCollectionSlug, markdownCollectionCategory };
-
-/**
- * Returns a list of category keys that have at least one associated Markdown file in the collection.
- * @param category The `MarkdownCollectionCategory` to check for non-empty categories.
- * @example
- * ```ts
- * import { listNonEmptyCategoryKeys, markdownCollectionCategory } from '@/utils/markdown-collection';
- *
- * const nonEmptyCategories = listNonEmptyCategoryKeys(markdownCollectionCategory);
- * console.log(nonEmptyCategories); // Output: ['javascript', 'markdown']
- * ```
- */
-export function listNonEmptyCategoryKeys(
-  category: MarkdownCollectionCategory,
-): CategoryKey[] {
-  return categoryKeys.filter(categoryKey => category[categoryKey].length > 0);
 }
+*/ // TODO

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -4,24 +4,52 @@
  * @see https://webpack.js.org/api/module-variables/#importmetawebpackcontext
  */
 
-// TODO: HMR 잘 되는듯?
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
 
 import { frontmatter } from '@lumir/utils';
 import { categoryKeys, type CategoryKey } from '@/data/category';
-import { type VMarkdownFile } from '@/data/v-markdown-file';
+import { type Frontmatter } from '@/data/frontmatter';
+import { type VMarkdownFileMeta, type VMarkdownFile } from '@/data/v-markdown-file';
 import { isFrontmatter } from '@/utils/is-frontmatter';
 
 // --------------------------------------------------------------------------------
 // Typedef
 // --------------------------------------------------------------------------------
 
-type MarkdownCollectionMap = Map<string, VMarkdownFile>;
-type MarkdownCollectionSlug = Record<string, VMarkdownFile>;
-type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFile[]>;
+type MarkdownCollectionMap = Map<string, VMarkdownFileMeta>;
+type MarkdownCollectionSlug = Record<string, VMarkdownFileMeta>;
+type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFileMeta[]>;
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+/**
+ * Asserts that the provided data conforms to the expected `Frontmatter` structure.
+ */
+function assertFrontmatter(data: unknown, slug: string): Frontmatter {
+  if (isFrontmatter(data)) {
+    return data;
+  }
+
+  throw new Error(
+    `
+Invalid frontmatter in Markdown file: \`${slug}\`
+
+Expected frontmatter format:
+  - \`title: string\`
+  - \`description: string\`
+  - \`created: string\`
+  - \`updated: string\`
+  - \`categories: CategoryKey[]\`
+  - \`references: string[]\`
+
+Received data: \`${JSON.stringify(data, null, 2)}\`
+`,
+  );
+}
 
 // --------------------------------------------------------------------------------
 // Class
@@ -47,15 +75,15 @@ class MarkdownCollection {
   // ------------------------------------------------------------------------------
 
   /**
-   * Lazily loads and processes Markdown files from the specified directory, extracting their frontmatter and content.
+   * Lazily loads and processes Markdown files from the specified directory, extracting their frontmatter.
    *
    * Performance Optimization:
    * - The method uses lazy loading to defer the loading and processing of Markdown files until they are actually needed.
    *   This can improve the initial load time of the application, especially if there are many Markdown files.
-   * - Once the Markdown files are loaded and processed, they are cached in the `#slug` property.
+   * - Once the Markdown files are loaded and processed, they are cached in the `#map` property.
    *   Subsequent calls to this method will return the cached data, avoiding redundant processing.
    */
-  #ensureMap(): Map<string, VMarkdownFile> {
+  #ensureMap(): Map<string, VMarkdownFileMeta> {
     const context = import.meta.webpackContext('../posts/docs', {
       recursive: false,
       regExp: /\.md$/,
@@ -73,27 +101,13 @@ class MarkdownCollection {
       }
 
       // If the Markdown file has not been processed, load and process it, then cache the result.
-      const { data, content } = frontmatter(context(key));
+      const { data } = frontmatter(context(key));
+      const sanitizedData = assertFrontmatter(data, slug);
 
-      if (!isFrontmatter(data)) {
-        throw new Error(
-          `
-Invalid frontmatter in Markdown file: \`${key}\`
-
-Expected frontmatter format:
-  - \`title: string\`
-  - \`description: string\`
-  - \`created: string\`
-  - \`updated: string\`
-  - \`categories: CategoryKey[]\`
-  - \`references: string[]\`
-
-Received data: \`${JSON.stringify(data, null, 2)}\`
-`,
-        );
-      }
-
-      this.#map.set(slug, { slug, data, content });
+      this.#map.set(slug, {
+        slug,
+        data: sanitizedData,
+      });
     }
 
     return this.#map;
@@ -127,7 +141,7 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
     }
 
     const markdownCollectionCategory = Object.fromEntries(
-      categoryKeys.map(categoryKey => [categoryKey, [] as VMarkdownFile[]]),
+      categoryKeys.map(categoryKey => [categoryKey, [] as VMarkdownFileMeta[]]),
     ) as MarkdownCollectionCategory;
 
     this.#ensureMap().forEach(vMarkdownFile => {
@@ -145,41 +159,56 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
   // Public Method
   // ------------------------------------------------------------------------------
 
-  async loadVMarkdownFile(slug: string): Promise<VMarkdownFile> {
+  /**
+   * Asynchronously loads the metadata of a Markdown file by its slug, without loading its content.
+   */
+  async loadVMarkdownFileMeta(slug: string): Promise<VMarkdownFileMeta> {
     const cached = this.#map.get(slug);
 
     if (cached) {
       return cached;
     }
 
+    const { data } = frontmatter(
+      // Markdown files are imported as raw strings because of a setting in `next.config.js`.
+      (await import(`../posts/docs/${slug}.md`)) as string,
+    );
+    const sanitizedData = assertFrontmatter(data, slug);
+
+    const vMarkdownFileMeta = {
+      slug,
+      data: sanitizedData,
+    };
+
+    // Cache the metadata in `#map` for future reference.
+    this.#map.set(slug, vMarkdownFileMeta);
+
+    return vMarkdownFileMeta;
+  }
+
+  /**
+   * Asynchronously loads a Markdown file by its slug, extracting its content and frontmatter metadata.
+   */
+  async loadVMarkdownFile(slug: string): Promise<VMarkdownFile> {
     const { data, content } = frontmatter(
       // Markdown files are imported as raw strings because of a setting in `next.config.js`.
       (await import(`../posts/docs/${slug}.md`)) as string,
     );
+    const sanitizedData = assertFrontmatter(data, slug);
 
-    if (!isFrontmatter(data)) {
-      throw new Error(
-        `
-Invalid frontmatter in Markdown file: \`${slug}\`
-
-Expected frontmatter format:
-  - \`title: string\`
-  - \`description: string\`
-  - \`created: string\`
-  - \`updated: string\`
-  - \`categories: CategoryKey[]\`
-  - \`references: string[]\`
-
-Received data: \`${JSON.stringify(data, null, 2)}\`
-`,
-      );
+    // Get a chance to cache the metadata in `#map` if it hasn't been cached already.
+    if (!this.#map.has(slug)) {
+      this.#map.set(slug, {
+        slug,
+        data: sanitizedData,
+      });
     }
 
-    const vMarkdownFile: VMarkdownFile = { slug, data, content };
-
-    this.#map.set(slug, vMarkdownFile);
-
-    return vMarkdownFile;
+    return {
+      slug,
+      data: sanitizedData,
+      content,
+    };
   }
 
   // ------------------------------------------------------------------------------
@@ -202,7 +231,6 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
    *         updated: '2024-01-02',
    *         categories: ['javascript', 'markdown'],
    *       },
-   *       content: '# Example Post\n\nThis is the content of the example post.',
    *     },
    *     // ...more
    *   ],
@@ -216,7 +244,6 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
    *         updated: '2024-01-02',
    *         categories: ['javascript', 'markdown'],
    *       },
-   *       content: '# Example Post\n\nThis is the content of the example post.',
    *     },
    *     // ...more
    *   ],
@@ -260,7 +287,6 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
    *       categories: ['javascript', 'markdown'],
    *       references: ['https://example.com'],
    *     },
-   *     content: '# Example Post\n\nThis is the content of the example post.',
    *   },
    *   // ...more
    * }

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -4,6 +4,8 @@
  * @see https://webpack.js.org/api/module-variables/#importmetawebpackcontext
  */
 
+// TODO: HMR 잘 되는듯?
+
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
@@ -17,8 +19,9 @@ import { isFrontmatter } from '@/utils/is-frontmatter';
 // Typedef
 // --------------------------------------------------------------------------------
 
-type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFile[]>;
+type MarkdownCollectionMap = Map<string, VMarkdownFile>;
 type MarkdownCollectionSlug = Record<string, VMarkdownFile>;
+type MarkdownCollectionCategory = Record<CategoryKey, VMarkdownFile[]>;
 
 // --------------------------------------------------------------------------------
 // Class
@@ -32,9 +35,12 @@ class MarkdownCollection {
   // Private Property
   // ------------------------------------------------------------------------------
 
-  #vMarkdownFiles: VMarkdownFile[] | null = null;
-  #category: MarkdownCollectionCategory | null = null;
+  /** Source of truth: used as a cache */
+  #map: MarkdownCollectionMap = new Map();
+  /** View: using `#map` as source of truth */
   #slug: MarkdownCollectionSlug | null = null;
+  /** View: using `#map` as source of truth */
+  #category: MarkdownCollectionCategory | null = null;
 
   // ------------------------------------------------------------------------------
   // Private Method
@@ -46,22 +52,27 @@ class MarkdownCollection {
    * Performance Optimization:
    * - The method uses lazy loading to defer the loading and processing of Markdown files until they are actually needed.
    *   This can improve the initial load time of the application, especially if there are many Markdown files.
-   * - Once the Markdown files are loaded and processed, they are cached in the `#vMarkdownFiles` property.
+   * - Once the Markdown files are loaded and processed, they are cached in the `#slug` property.
    *   Subsequent calls to this method will return the cached data, avoiding redundant processing.
    */
-  #ensureVMarkdownFiles(): VMarkdownFile[] {
-    // If the Markdown files have already been loaded, skip the loading process.
-    if (this.#vMarkdownFiles) {
-      return this.#vMarkdownFiles;
-    }
-
+  #ensureMap(): Map<string, VMarkdownFile> {
     const context = import.meta.webpackContext('../posts/docs', {
       recursive: false,
       regExp: /\.md$/,
       mode: 'sync',
     });
 
-    const vMarkdownFiles: VMarkdownFile[] = context.keys().map(key => {
+    for (const key of context.keys()) {
+      const slug = key.replace(/^\.\//, '').replace(/\.md$/, '');
+
+      // If the Markdown file has already been processed and cached, skip the loading and processing steps.
+      const cached = this.#map.get(slug);
+
+      if (cached) {
+        continue;
+      }
+
+      // If the Markdown file has not been processed, load and process it, then cache the result.
       const { data, content } = frontmatter(context(key));
 
       if (!isFrontmatter(data)) {
@@ -82,16 +93,28 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
         );
       }
 
-      return {
-        slug: key.replace(/^\.\//, '').replace(/\.md$/, ''),
-        data,
-        content,
-      };
-    });
+      this.#map.set(slug, { slug, data, content });
+    }
 
-    this.#vMarkdownFiles = vMarkdownFiles;
+    return this.#map;
+  }
 
-    return vMarkdownFiles;
+  /**
+   * Lazily creates a mapping of slugs to their corresponding Markdown file metadata.
+   */
+  #ensureSlug(): MarkdownCollectionSlug {
+    // If the slug mapping has already been created, skip the creation process.
+    if (this.#slug) {
+      return this.#slug;
+    }
+
+    const markdownCollectionSlug = Object.fromEntries(
+      this.#ensureMap(),
+    ) as MarkdownCollectionSlug;
+
+    this.#slug = markdownCollectionSlug;
+
+    return markdownCollectionSlug;
   }
 
   /**
@@ -107,7 +130,7 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
       categoryKeys.map(categoryKey => [categoryKey, [] as VMarkdownFile[]]),
     ) as MarkdownCollectionCategory;
 
-    this.#ensureVMarkdownFiles().forEach(vMarkdownFile => {
+    this.#ensureMap().forEach(vMarkdownFile => {
       vMarkdownFile.data.categories.forEach(category => {
         markdownCollectionCategory[category].push(vMarkdownFile);
       });
@@ -118,24 +141,45 @@ Received data: \`${JSON.stringify(data, null, 2)}\`
     return markdownCollectionCategory;
   }
 
-  /**
-   * Lazily creates a mapping of slugs to their corresponding Markdown file metadata.
-   */
-  #ensureSlug(): MarkdownCollectionSlug {
-    // If the slug mapping has already been created, skip the creation process.
-    if (this.#slug) {
-      return this.#slug;
+  // ------------------------------------------------------------------------------
+  // Public Method
+  // ------------------------------------------------------------------------------
+
+  async loadVMarkdownFile(slug: string): Promise<VMarkdownFile> {
+    const cached = this.#map.get(slug);
+
+    if (cached) {
+      return cached;
     }
 
-    const markdownCollectionSlug: MarkdownCollectionSlug = {};
+    const { data, content } = frontmatter(
+      // Markdown files are imported as raw strings because of a setting in `next.config.js`.
+      (await import(`../posts/docs/${slug}.md`)) as string,
+    );
 
-    this.#ensureVMarkdownFiles().forEach(vMarkdownFile => {
-      markdownCollectionSlug[vMarkdownFile.slug] = vMarkdownFile;
-    });
+    if (!isFrontmatter(data)) {
+      throw new Error(
+        `
+Invalid frontmatter in Markdown file: \`${slug}\`
 
-    this.#slug = markdownCollectionSlug;
+Expected frontmatter format:
+  - \`title: string\`
+  - \`description: string\`
+  - \`created: string\`
+  - \`updated: string\`
+  - \`categories: CategoryKey[]\`
+  - \`references: string[]\`
 
-    return markdownCollectionSlug;
+Received data: \`${JSON.stringify(data, null, 2)}\`
+`,
+      );
+    }
+
+    const vMarkdownFile: VMarkdownFile = { slug, data, content };
+
+    this.#map.set(slug, vMarkdownFile);
+
+    return vMarkdownFile;
   }
 
   // ------------------------------------------------------------------------------
@@ -251,38 +295,3 @@ export default function createMarkdownCollection() {
 
   return markdownCollection;
 }
-
-// --------------------------------------------------------------------------------
-// TODO
-// --------------------------------------------------------------------------------
-
-/*
-export async function loadMarkdownFile(slug: string): Promise<VMarkdownFile> {
-  const markdownFile = (await import(`../posts/docs/${slug}.md`)) as string;
-  const { data, content } = frontmatter(markdownFile);
-
-  if (!isFrontmatter(data)) {
-    throw new Error(
-      `
-Invalid frontmatter in Markdown file: \`${slug}.md\`
-
-Expected frontmatter format:
-  - \`title: string\`
-  - \`description: string\`
-  - \`created: string\`
-  - \`updated: string\`
-  - \`categories: CategoryKey[]\`
-  - \`references: string[]\`
-
-Received data: \`${JSON.stringify(data, null, 2)}\`
-`,
-    );
-  }
-
-  return {
-    slug,
-    data,
-    content,
-  };
-}
-*/ // TODO

--- a/apps/blog/src/utils/markdown-collection.ts
+++ b/apps/blog/src/utils/markdown-collection.ts
@@ -171,7 +171,7 @@ class MarkdownCollection {
 
     const { data } = frontmatter(
       // Markdown files are imported as raw strings because of a setting in `next.config.js`.
-      (await import(`../posts/docs/${slug}.md`)) as string,
+      (await import(`../posts/docs/${slug}.md`)).default as string,
     );
     const sanitizedData = assertFrontmatter(data, slug);
 
@@ -192,7 +192,7 @@ class MarkdownCollection {
   async loadVMarkdownFile(slug: string): Promise<VMarkdownFile> {
     const { data, content } = frontmatter(
       // Markdown files are imported as raw strings because of a setting in `next.config.js`.
-      (await import(`../posts/docs/${slug}.md`)) as string,
+      (await import(`../posts/docs/${slug}.md`)).default as string,
     );
     const sanitizedData = assertFrontmatter(data, slug);
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,7 @@ export default defineConfig([
     languageOptions: {
       globals: {
         PageProps: false, // Next.js
+        __WebpackModuleApi: false, // Webpack
       },
     },
     rules: {

--- a/packages/utils/src/frontmatter.test.ts
+++ b/packages/utils/src/frontmatter.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import { frontmatter } from './frontmatter.js';
+import { frontmatter, frontmatterData } from './frontmatter.js';
 
 // --------------------------------------------------------------------------------
 // Test
@@ -16,108 +16,139 @@ import { frontmatter } from './frontmatter.js';
 describe('frontmatter', () => {
   describe('when there is a front matter', () => {
     it('should handle empty YAML front matter as `null`', () => {
-      const result = frontmatter('---\n---\nHello, world!');
-
-      assert.deepStrictEqual(result, {
+      const input = '---\n---\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: null,
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should handle front matter without content as an empty string', () => {
-      const result = frontmatter('---\ntitle: Title\nauthor: Author\n---');
-
-      assert.deepStrictEqual(result, {
+      const input = '---\ntitle: Title\nauthor: Author\n---';
+      const expected = {
         content: '',
         data: {
           title: 'Title',
           author: 'Author',
         },
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should parse CRLF front matter correctly', () => {
-      const result = frontmatter(
-        '---\r\ntitle: Title\r\nauthor: Author\r\n---\r\nHello, world!',
-      );
-
-      assert.deepStrictEqual(result, {
+      const input = '---\r\ntitle: Title\r\nauthor: Author\r\n---\r\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: {
           title: 'Title',
           author: 'Author',
         },
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should parse CR front matter correctly', () => {
       // Note: The YAML parser does not support CR line endings, so CR characters within YAML may not parse correctly.
       // This test intentionally mixes CR and CRLF line endings to verify parsing behavior.
-      const result = frontmatter(
-        '---\rtitle: Title\r\nauthor: Author\r---\rHello, world!',
-      );
-
-      assert.deepStrictEqual(result, {
+      const input = '---\rtitle: Title\r\nauthor: Author\r---\rHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: {
           title: 'Title',
           author: 'Author',
         },
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should parse LF front matter correctly', () => {
-      const result = frontmatter('---\ntitle: Title\nauthor: Author\n---\nHello, world!');
-
-      assert.deepStrictEqual(result, {
+      const input = '---\ntitle: Title\nauthor: Author\n---\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: {
           title: 'Title',
           author: 'Author',
         },
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should parse front matter with emojis correctly', () => {
-      const result = frontmatter(
-        '---\ntitle: "Title with emoji 😊"\nauthor: "Author with emoji 😎"\n---\nHello, world!',
-      );
-
-      assert.deepStrictEqual(result, {
+      const input =
+        '---\ntitle: "Title with emoji 😊"\nauthor: "Author with emoji 😎"\n---\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: {
           title: 'Title with emoji 😊',
           author: 'Author with emoji 😎',
         },
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should handle front matter with a numeric value', () => {
-      const result = frontmatter('---\n1\n---\nHello, world!');
-
-      assert.deepStrictEqual(result, {
+      const input = '---\n1\n---\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: 1,
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
 
     it('should handle front matter with an array value', () => {
-      const result = frontmatter('---\n[1, 2, 3]\n---\nHello, world!');
-
-      assert.deepStrictEqual(result, {
+      const input = '---\n[1, 2, 3]\n---\nHello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: [1, 2, 3],
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
   });
 
   describe('when there is no front matter', () => {
     it('should return the original content and `null` data', () => {
-      const result = frontmatter('Hello, world!');
-
-      assert.deepStrictEqual(result, {
+      const input = 'Hello, world!';
+      const expected = {
         content: 'Hello, world!',
         data: null,
+      };
+
+      assert.deepStrictEqual(frontmatter(input), expected);
+      assert.deepStrictEqual(frontmatterData(input), {
+        data: expected.data,
       });
     });
   });

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -2,8 +2,6 @@
  * @fileoverview frontmatter.
  */
 
-/* eslint-disable import/prefer-default-export -- TODO: Refactor to use named exports */
-
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
@@ -61,6 +59,39 @@ export function frontmatter(input: string): {
 
   return {
     content: input.slice(match[0].length),
+    data: yaml.parse(match.groups?.yaml ?? ''),
+  };
+}
+
+/**
+ * Parses the front matter from a string and returns only the parsed data.
+ * If no front matter is found, it returns `null` data.
+ * @example
+ *
+ * ```ts
+ * import { frontmatterData } from '@lumir/utils';
+ *
+ * const result = frontmatterData(`---\ntitle: Title\nauthor: Author\n---\nHello, world!`);
+ *
+ * console.log(result);
+ * // {
+ * //   data: {
+ * //     title: 'Title',
+ * //     author: 'Author',
+ * //   },
+ * // }
+ * ```
+ */
+export function frontmatterData(input: string): { data: unknown } {
+  const match = input.match(frontmatterRegex);
+
+  if (!match) {
+    return {
+      data: null,
+    };
+  }
+
+  return {
     data: yaml.parse(match.groups?.yaml ?? ''),
   };
 }

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import { cn, frontmatter } from './index.js';
+import { cn, frontmatter, frontmatterData } from './index.js';
 
 // --------------------------------------------------------------------------------
 // Test
@@ -23,6 +23,11 @@ describe('index', () => {
     it('`frontmatter` should be defined', () => {
       assert.isDefined(frontmatter);
       assert.strictEqual(typeof frontmatter, 'function');
+    });
+
+    it('`frontmatterData` should be defined', () => {
+      assert.isDefined(frontmatterData);
+      assert.strictEqual(typeof frontmatterData, 'function');
     });
   });
 });


### PR DESCRIPTION
This pull request refactors how markdown collections are managed and accessed throughout the blog application. The main improvement is the introduction of a `createMarkdownCollection` factory, which centralizes and standardizes access to markdown data, replacing previous direct imports and scattered utility usage. This change improves maintainability, consistency, and testability. Additionally, the `VMarkdownFile` type is split into `VMarkdownFileMeta` and `VMarkdownFile` for clearer separation of metadata and content, and a new test ensures the singleton behavior of the markdown collection.

**Refactoring markdown collection access:**

* Introduced `createMarkdownCollection` as the standard way to access markdown data, replacing direct imports like `markdownCollectionCategory`, `markdownCollectionSlug`, and related utility functions in all relevant files. ([apps/blog/src/app/categories/[category]/page.tsxL15-R23](diffhunk://#diff-5da4c79928389c550275ad5311f22d8cd39e2445c5160d5296e66bb5f230c2efL15-R23), [[1]](diffhunk://#diff-4fa80ec2c7821fb4902f5293a2727982485cc0648d44ce5b0b8118d82cec36b9L11-R24) [apps/blog/src/app/posts/[markdown]/page.tsxL10-R19](diffhunk://#diff-a69b8cf2fe68b54920e6f74f5ccdcac11207d98bace99df45ba054ba14796a27L10-R19), [[2]](diffhunk://#diff-3193e8e060d6f9c062f0e007f89e4e4cb55db65ed93f20f099811febc4d7808dL11-R24) [[3]](diffhunk://#diff-dfe3b1759f7a2daa3c5c3e2b31aa81882f17d2020531f0b49e14893b29110566L13-R20)
* Updated all usages to access categories, slugs, and category keys through the new `markdownCollection` instance. ([apps/blog/src/app/categories/[category]/page.tsxL37-R40](diffhunk://#diff-5da4c79928389c550275ad5311f22d8cd39e2445c5160d5296e66bb5f230c2efL37-R40), [apps/blog/src/app/categories/[category]/page.tsxL62-R68](diffhunk://#diff-5da4c79928389c550275ad5311f22d8cd39e2445c5160d5296e66bb5f230c2efL62-R68), [[1]](diffhunk://#diff-4fa80ec2c7821fb4902f5293a2727982485cc0648d44ce5b0b8118d82cec36b9L11-R24) [apps/blog/src/app/posts/[markdown]/page.tsxL30-R36](diffhunk://#diff-a69b8cf2fe68b54920e6f74f5ccdcac11207d98bace99df45ba054ba14796a27L30-R36), [apps/blog/src/app/posts/[markdown]/page.tsxL42-R50](diffhunk://#diff-a69b8cf2fe68b54920e6f74f5ccdcac11207d98bace99df45ba054ba14796a27L42-R50), [apps/blog/src/app/posts/[markdown]/page.tsxL59-R67](diffhunk://#diff-a69b8cf2fe68b54920e6f74f5ccdcac11207d98bace99df45ba054ba14796a27L59-R67), [[2]](diffhunk://#diff-3193e8e060d6f9c062f0e007f89e4e4cb55db65ed93f20f099811febc4d7808dL11-R24) [[3]](diffhunk://#diff-dfe3b1759f7a2daa3c5c3e2b31aa81882f17d2020531f0b49e14893b29110566L32-R29) [[4]](diffhunk://#diff-dfe3b1759f7a2daa3c5c3e2b31aa81882f17d2020531f0b49e14893b29110566L50-R47)

**Type improvements:**

* Split `VMarkdownFile` into `VMarkdownFileMeta` (for metadata only) and `VMarkdownFile` (which extends the meta type and includes content), and updated all relevant type annotations and usages to reflect this change. [[1]](diffhunk://#diff-6b48d6fac0a73edf656076732ef871acceeca3fcaa34cc3aa46ab74581cd6d82L16-R18) [[2]](diffhunk://#diff-6b48d6fac0a73edf656076732ef871acceeca3fcaa34cc3aa46ab74581cd6d82R28-R33) [[3]](diffhunk://#diff-27ace779818054f218418cac3cbd1402fff00ac2cafed1772b6a0caef81b4918L14-R14) [[4]](diffhunk://#diff-27ace779818054f218418cac3cbd1402fff00ac2cafed1772b6a0caef81b4918L44-R49) [[5]](diffhunk://#diff-8c399083e87134cbc7af9993e79afe4647d8cf49f8a265bc1abc40518b319cc0L13-R13) [[6]](diffhunk://#diff-8c399083e87134cbc7af9993e79afe4647d8cf49f8a265bc1abc40518b319cc0L26-R26) [[7]](diffhunk://#diff-8c399083e87134cbc7af9993e79afe4647d8cf49f8a265bc1abc40518b319cc0L37-R37)

**Testing and reliability:**

* Added a unit test (`markdown-collection.test.ts`) to verify that `createMarkdownCollection` returns a singleton instance, ensuring consistent state throughout the application.