### PR TITLE
refactor(blog): streamline localized name representation and turn off `import/no-cycle` eslint rule

### DIFF
--- a/apps/blog/src/data/meta.ts
+++ b/apps/blog/src/data/meta.ts
@@ -13,23 +13,28 @@ import { type JSX } from 'react';
 // --------------------------------------------------------------------------------
 
 /**
+ * Represents localized display names in English and Korean.
+ */
+export interface LocalizedName {
+  /**
+   * The display name in English.
+   */
+  readonly en: string;
+
+  /**
+   * The display name in Korean.
+   */
+  readonly ko: string;
+}
+
+/**
  * Represents shared metadata with localized display names and an associated React icon.
  */
 export interface Meta {
   /**
    * The localized display name in English and Korean.
    */
-  readonly name: {
-    /**
-     * The display name in English.
-     */
-    readonly en: string;
-
-    /**
-     * The display name in Korean.
-     */
-    readonly ko: string;
-  };
+  readonly name: LocalizedName;
 
   /**
    * The React icon associated with the metadata item, represented as a JSX element.

--- a/apps/blog/src/data/sort.tsx
+++ b/apps/blog/src/data/sort.tsx
@@ -29,15 +29,15 @@ export type SortKey = keyof typeof sortMeta;
 export const sortMeta = {
   asc: {
     name: {
-      ko: '오름차순',
       en: 'Asc',
+      ko: '오름차순',
     },
     reactIcons: <FaArrowUpShortWide />,
   },
   desc: {
     name: {
-      ko: '내림차순',
       en: 'Desc',
+      ko: '내림차순',
     },
     reactIcons: <FaArrowDownWideShort />,
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,12 @@ export default defineConfig([
 
   // js
   {
+    name: 'js/global',
+    rules: {
+      'import/no-cycle': 'off', // Too computationally expensive. TODO: Remove this in shared config.
+    },
+  },
+  {
     name: 'js/apps/blog',
     files: ['apps/blog/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
     settings: {


### PR DESCRIPTION
This pull request refactors type definitions for metadata localization, fixes the order of localized fields in `sortMeta`, and updates ESLint configuration to improve performance. The main changes are grouped below:

### Type definition refactoring

* Extracted the localized name fields into a new `LocalizedName` interface and updated the `Meta` interface to use `LocalizedName` for better type clarity and reusability. [[1]](diffhunk://#diff-dc1c34abb9cc824399d08a5b2069ec4fac7dca660737360ac543113aa236dd4cL16-R18) [[2]](diffhunk://#diff-dc1c34abb9cc824399d08a5b2069ec4fac7dca660737360ac543113aa236dd4cL32-R37)

### Data consistency

* Fixed the order of `en` and `ko` fields in the `sortMeta` object to ensure consistency and correct localization display.

### ESLint configuration

* Disabled the `import/no-cycle` rule globally in the ESLint config due to performance concerns, with a note to revisit this in the shared config.