### PR TITLE
ci(*): speed up test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Install playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium --with-deps --only-shell
 
       - name: Build
         run: npm run build:pkg


### PR DESCRIPTION
This pull request updates the Playwright browser installation step in the CI workflow to optimize the installation process.

CI workflow improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R60): Changed the Playwright installation command to use `npx playwright install chromium --with-deps --only-shell` for a more efficient and targeted installation of Chromium and its dependencies.