### PR TITLE
feat(@lumir/react-kit): enhance `useToggle` hook with detailed overloads

### DIFF
--- a/apps/blog/src/components/common/theme-context.tsx
+++ b/apps/blog/src/components/common/theme-context.tsx
@@ -12,14 +12,8 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-  type PropsWithChildren,
-} from 'react';
+import { createContext, useContext, useEffect, type PropsWithChildren } from 'react';
+import { useToggle } from '@lumir/react-kit/hooks';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -109,14 +103,18 @@ export function useThemeContext(): ThemeContextValue {
  * ```
  */
 export function ThemeProvider({ children }: PropsWithChildren) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // During server-side rendering, `document` is not available, so we return the default theme.
-    if (typeof document === 'undefined') {
-      return defaultTheme;
-    }
+  const [theme, toggleTheme] = useToggle<Theme>(
+    () => {
+      // During server-side rendering, `document` is not available, so we return the default theme.
+      if (typeof document === 'undefined') {
+        return defaultTheme;
+      }
 
-    return (document.documentElement.getAttribute(themeKey) ?? defaultTheme) as Theme;
-  });
+      return (document.documentElement.getAttribute(themeKey) ?? defaultTheme) as Theme;
+    },
+    'dark',
+    'light',
+  );
 
   useEffect(() => {
     // 1. Update the `data-theme` attribute on the root document element to apply the theme globally.
@@ -127,10 +125,6 @@ export function ThemeProvider({ children }: PropsWithChildren) {
     // protocols, or ports. It can only collide with other apps running on the same origin.
     localStorage.setItem(themeKey, theme);
   }, [theme]);
-
-  const toggleTheme = useCallback(() => {
-    setTheme(previousTheme => (previousTheme === 'dark' ? 'light' : 'dark'));
-  }, []);
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values -- React Compiler automatically optimizes context values.
   return <ThemeContext value={[theme, toggleTheme]}>{children}</ThemeContext>;

--- a/packages/react-kit/src/hooks/use-toggle.test.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test.ts
@@ -90,6 +90,14 @@ describe('use-toggle', () => {
     assert.strictEqual(typeof toggle, 'function');
   });
 
+  it('Initial value function should be used as the initial state value when three values are provided', async () => {
+    const { result } = await renderHook(() => useToggle(() => 'open', 'closed', 'open'));
+    const [state, toggle] = result.current;
+
+    assert.strictEqual(state, 'open');
+    assert.strictEqual(typeof toggle, 'function');
+  });
+
   it('`toggle` function should toggle between the provided state values', async () => {
     const { act, result } = await renderHook(() =>
       useToggle<'dark' | 'light'>('light', 'dark', 'light'),

--- a/packages/react-kit/src/hooks/use-toggle.test.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test.ts
@@ -15,19 +15,12 @@ import { useToggle } from './use-toggle.js';
 // --------------------------------------------------------------------------------
 
 describe('use-toggle', () => {
+  // First overload: `useToggle()`
   it('Default initial value should be `false` when not provided', async () => {
     const { result } = await renderHook(() => useToggle());
     const [state, toggle] = result.current;
 
     assert.strictEqual(state, false);
-    assert.strictEqual(typeof toggle, 'function');
-  });
-
-  it('Initial value should be `true` when provided', async () => {
-    const { result } = await renderHook(() => useToggle(true));
-    const [state, toggle] = result.current;
-
-    assert.strictEqual(state, true);
     assert.strictEqual(typeof toggle, 'function');
   });
 
@@ -53,5 +46,73 @@ describe('use-toggle', () => {
     const [thirdState] = result.current;
 
     assert.strictEqual(thirdState, false);
+  });
+
+  // Second overload: `useToggle(initialValue)`
+  it('Initial value should be `true` when provided', async () => {
+    const { result } = await renderHook(() => useToggle(true));
+    const [state, toggle] = result.current;
+
+    assert.strictEqual(state, true);
+    assert.strictEqual(typeof toggle, 'function');
+  });
+
+  it('`toggle` function should toggle the state value', async () => {
+    const { act, result } = await renderHook(() => useToggle(true));
+
+    const [firstState, toggle] = result.current;
+
+    assert.strictEqual(firstState, true);
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [secondState] = result.current;
+
+    assert.strictEqual(secondState, false);
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [thirdState] = result.current;
+
+    assert.strictEqual(thirdState, true);
+  });
+
+  // Third overload: `useToggle(firstValue, secondValue)`
+  it('First value should be used as the initial value when two values are provided', async () => {
+    const { result } = await renderHook(() => useToggle('closed', 'open'));
+    const [state, toggle] = result.current;
+
+    assert.strictEqual(state, 'closed');
+    assert.strictEqual(typeof toggle, 'function');
+  });
+
+  it('`toggle` function should toggle between the provided state values', async () => {
+    const { act, result } = await renderHook(() =>
+      useToggle<'dark' | 'light'>('dark', 'light'),
+    );
+
+    const [firstState, toggle] = result.current;
+
+    assert.strictEqual(firstState, 'dark');
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [secondState] = result.current;
+
+    assert.strictEqual(secondState, 'light');
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [thirdState] = result.current;
+
+    assert.strictEqual(thirdState, 'dark');
   });
 });

--- a/packages/react-kit/src/hooks/use-toggle.test.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test.ts
@@ -81,23 +81,23 @@ describe('use-toggle', () => {
     assert.strictEqual(thirdState, true);
   });
 
-  // Third overload: `useToggle(firstValue, secondValue)`
-  it('First value should be used as the initial value when two values are provided', async () => {
-    const { result } = await renderHook(() => useToggle('closed', 'open'));
+  // Third overload: `useToggle(initialValue, firstValue, secondValue)`
+  it('Initial value should be used as the initial state value when three values are provided', async () => {
+    const { result } = await renderHook(() => useToggle('open', 'closed', 'open'));
     const [state, toggle] = result.current;
 
-    assert.strictEqual(state, 'closed');
+    assert.strictEqual(state, 'open');
     assert.strictEqual(typeof toggle, 'function');
   });
 
   it('`toggle` function should toggle between the provided state values', async () => {
     const { act, result } = await renderHook(() =>
-      useToggle<'dark' | 'light'>('dark', 'light'),
+      useToggle<'dark' | 'light'>('light', 'dark', 'light'),
     );
 
     const [firstState, toggle] = result.current;
 
-    assert.strictEqual(firstState, 'dark');
+    assert.strictEqual(firstState, 'light');
 
     await act(async () => {
       toggle();
@@ -105,7 +105,7 @@ describe('use-toggle', () => {
 
     const [secondState] = result.current;
 
-    assert.strictEqual(secondState, 'light');
+    assert.strictEqual(secondState, 'dark');
 
     await act(async () => {
       toggle();
@@ -113,6 +113,6 @@ describe('use-toggle', () => {
 
     const [thirdState] = result.current;
 
-    assert.strictEqual(thirdState, 'dark');
+    assert.strictEqual(thirdState, 'light');
   });
 });

--- a/packages/react-kit/src/hooks/use-toggle.ts
+++ b/packages/react-kit/src/hooks/use-toggle.ts
@@ -64,10 +64,11 @@ export function useToggle(
 
 /**
  * `useToggle` is a React hook that simplifies managing a state with two
- * explicit values. It initializes the state with the initial value and provides
- * a function to toggle it between the first and second value.
+ * explicit values. It initializes the state with the initial value or a
+ * function that returns it, and provides a function to toggle it between the
+ * first and second value.
  *
- * @param initialValue The initial state value.
+ * @param initialValue The initial state value or a function that returns it.
  * @param firstValue The first state value.
  * @param secondValue The second state value to toggle to.
  * @returns Current state and a function that toggles it.
@@ -78,7 +79,7 @@ export function useToggle(
  * type Theme = 'dark' | 'light';
  *
  * function Component() {
- *   const [theme, toggleTheme] = useToggle<Theme>('light', 'dark', 'light');
+ *   const [theme, toggleTheme] = useToggle<Theme>(() => 'light', 'dark', 'light');
  *
  *   return (
  *     <button type="button" onClick={toggleTheme}>
@@ -89,7 +90,7 @@ export function useToggle(
  * ```
  */
 export function useToggle<const T>(
-  initialValue: NoInfer<T>,
+  initialValue: NoInfer<T> | (() => NoInfer<T>),
   firstValue: T,
   secondValue: T,
 ): readonly [state: T, toggle: () => void];
@@ -99,13 +100,13 @@ export function useToggle<const T>(
 // --------------------------------------------------------------------------------
 
 export function useToggle<const T>(
-  initialValue: boolean | T = false,
+  initialValue: boolean | T | (() => T) = false,
   ...rest: [] | [firstValue: T, secondValue: T]
 ): readonly [state: boolean | T, toggle: () => void] {
   const [state, setState] = useState<boolean | T>(initialValue);
 
-  const firstValue = rest.length !== 0 ? rest[0] : initialValue;
-  const secondValue = rest.length !== 0 ? rest[1] : !initialValue;
+  const firstValue = rest.length === 2 ? rest[0] : !!initialValue;
+  const secondValue = rest.length === 2 ? rest[1] : !initialValue;
 
   const toggle = useCallback(() => {
     setState(prevState => (Object.is(prevState, secondValue) ? firstValue : secondValue));

--- a/packages/react-kit/src/hooks/use-toggle.ts
+++ b/packages/react-kit/src/hooks/use-toggle.ts
@@ -10,14 +10,38 @@
 import { useCallback, useState } from 'react';
 
 // --------------------------------------------------------------------------------
-// Export
+// Overload
 // --------------------------------------------------------------------------------
 
 /**
  * `useToggle` is a React hook that simplifies managing a boolean state.
- * It provides a function to toggle the state between `true` and `false`.
+ * It initializes the state to `false` and provides a function to toggle it
+ * between `true` and `false`.
  *
- * @param initialValue The initial state value. Defaults to `false`.
+ * @returns Current boolean state and a function that toggles it.
+ * @example
+ * ```tsx
+ * import { useToggle } from '@lumir/react-kit/hooks';
+ *
+ * function Component() {
+ *   const [isOpen, toggleIsOpen] = useToggle();
+ *
+ *   return (
+ *     <button type="button" onClick={toggleIsOpen}>
+ *       {isOpen ? 'Close' : 'Open'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useToggle(): readonly [state: boolean, toggle: () => void];
+
+/**
+ * `useToggle` is a React hook that simplifies managing a boolean state.
+ * It initializes the state with the provided boolean value and provides a
+ * function to toggle it between `true` and `false`.
+ *
+ * @param initialValue The initial boolean state value.
  * @returns Current boolean state and a function that toggles it.
  * @example
  * ```tsx
@@ -27,22 +51,62 @@ import { useCallback, useState } from 'react';
  *   const [isOpen, toggleIsOpen] = useToggle(false);
  *
  *   return (
- *     <div>
- *       <p>Bottom Sheet state: {isOpen ? 'opened' : 'closed'}</p>
- *       <button onClick={toggleIsOpen}>Toggle</button>
- *     </div>
+ *     <button type="button" onClick={toggleIsOpen}>
+ *       {isOpen ? 'Close' : 'Open'}
+ *     </button>
  *   );
  * }
  * ```
  */
 export function useToggle(
-  initialValue = false,
-): readonly [state: boolean, toggle: () => void] {
-  const [state, setState] = useState<boolean>(initialValue);
+  initialValue: boolean,
+): readonly [state: boolean, toggle: () => void];
+
+/**
+ * `useToggle` is a React hook that simplifies managing a state with two
+ * explicit values. It initializes the state with the first value and provides
+ * a function to toggle it between the first and second value.
+ *
+ * @param firstValue The initial state value.
+ * @param secondValue The second state value to toggle to.
+ * @returns Current state and a function that toggles it.
+ * @example
+ * ```tsx
+ * import { useToggle } from '@lumir/react-kit/hooks';
+ *
+ * type Theme = 'dark' | 'light';
+ *
+ * function Component() {
+ *   const [theme, toggleTheme] = useToggle<Theme>('dark', 'light');
+ *
+ *   return (
+ *     <button type="button" onClick={toggleTheme}>
+ *       {theme}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useToggle<const T>(
+  firstValue: T,
+  secondValue: T,
+): readonly [state: T, toggle: () => void];
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+export function useToggle<const T>(
+  firstValue: boolean | T = false,
+  ...rest: [] | [secondValue: T]
+): readonly [state: boolean | T, toggle: () => void] {
+  const [state, setState] = useState<boolean | T>(firstValue);
+
+  const secondValue = rest.length !== 0 ? rest[0] : !firstValue;
 
   const toggle = useCallback(() => {
-    setState(prevState => !prevState);
-  }, []);
+    setState(prevState => (Object.is(prevState, secondValue) ? firstValue : secondValue));
+  }, [firstValue, secondValue]);
 
   return [state, toggle] as const;
 }

--- a/packages/react-kit/src/hooks/use-toggle.ts
+++ b/packages/react-kit/src/hooks/use-toggle.ts
@@ -64,10 +64,11 @@ export function useToggle(
 
 /**
  * `useToggle` is a React hook that simplifies managing a state with two
- * explicit values. It initializes the state with the first value and provides
+ * explicit values. It initializes the state with the initial value and provides
  * a function to toggle it between the first and second value.
  *
- * @param firstValue The initial state value.
+ * @param initialValue The initial state value.
+ * @param firstValue The first state value.
  * @param secondValue The second state value to toggle to.
  * @returns Current state and a function that toggles it.
  * @example
@@ -77,7 +78,7 @@ export function useToggle(
  * type Theme = 'dark' | 'light';
  *
  * function Component() {
- *   const [theme, toggleTheme] = useToggle<Theme>('dark', 'light');
+ *   const [theme, toggleTheme] = useToggle<Theme>('light', 'dark', 'light');
  *
  *   return (
  *     <button type="button" onClick={toggleTheme}>
@@ -88,6 +89,7 @@ export function useToggle(
  * ```
  */
 export function useToggle<const T>(
+  initialValue: NoInfer<T>,
   firstValue: T,
   secondValue: T,
 ): readonly [state: T, toggle: () => void];
@@ -97,12 +99,13 @@ export function useToggle<const T>(
 // --------------------------------------------------------------------------------
 
 export function useToggle<const T>(
-  firstValue: boolean | T = false,
-  ...rest: [] | [secondValue: T]
+  initialValue: boolean | T = false,
+  ...rest: [] | [firstValue: T, secondValue: T]
 ): readonly [state: boolean | T, toggle: () => void] {
-  const [state, setState] = useState<boolean | T>(firstValue);
+  const [state, setState] = useState<boolean | T>(initialValue);
 
-  const secondValue = rest.length !== 0 ? rest[0] : !firstValue;
+  const firstValue = rest.length !== 0 ? rest[0] : initialValue;
+  const secondValue = rest.length !== 0 ? rest[1] : !initialValue;
 
   const toggle = useCallback(() => {
     setState(prevState => (Object.is(prevState, secondValue) ? firstValue : secondValue));


### PR DESCRIPTION
This pull request introduces a more flexible and robust `useToggle` hook in the `@lumir/react-kit/hooks` package, allowing it to toggle between any two values (not just booleans). The changes are also integrated into the blog's theme context to simplify and improve theme toggling. Comprehensive tests have been added to verify the new behavior.

**Enhancements to `useToggle` hook:**

* Refactored `useToggle` to support toggling between any two values (not limited to booleans) by introducing overloads and a generalized implementation. [[1]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL13-R44) [[2]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL30-R113)
* Improved documentation and usage examples for all overloads of `useToggle`. [[1]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL13-R44) [[2]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL30-R113)

**Integration and usage improvements:**

* Updated the blog's `ThemeProvider` to use the new `useToggle` API for toggling between `'dark'` and `'light'` themes, removing redundant code. [[1]](diffhunk://#diff-e380da07859ef8b8bd720fced3d8ec9f305471190a2162c097359cff3c709b48L15-R16) [[2]](diffhunk://#diff-e380da07859ef8b8bd720fced3d8ec9f305471190a2162c097359cff3c709b48L112-R117) [[3]](diffhunk://#diff-e380da07859ef8b8bd720fced3d8ec9f305471190a2162c097359cff3c709b48L131-L134)

**Testing:**

* Added and expanded tests for all overloads of `useToggle`, including toggling between booleans and custom values, and verifying correct initial state and toggling behavior. [[1]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24R18) [[2]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24R27-R51) [[3]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L35-R124)