### PR TITLE
chore(*): enable typecheck for `scripts`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "stylelint.vscode-stylelint",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
-    "davidanson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint",
+    "vitest.explorer"
   ]
 }

--- a/scripts/clang-format.js
+++ b/scripts/clang-format.js
@@ -8,9 +8,11 @@ const args = process.argv[2] === '--fix' ? ['-i'] : ['-n', '-Werror'];
 const apps = join(import.meta.dirname, '..', 'apps', 'blog', 'src');
 const archives = join(import.meta.dirname, '..', 'archives');
 
-const appsPaths = readdirSync(apps, { recursive: true }).map(path => join(apps, path));
-const archivesPaths = readdirSync(archives, { recursive: true }).map(path =>
-  join(archives, path),
+const appsPaths = readdirSync(apps, { encoding: 'utf8', recursive: true }).map(path =>
+  join(apps, path),
+);
+const archivesPaths = readdirSync(archives, { encoding: 'utf8', recursive: true }).map(
+  path => join(archives, path),
 );
 
 const paths = [...appsPaths, ...archivesPaths].filter(path =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,10 @@
     "**/*.config.cjs",
     "**/*.config.ts",
     "**/*.config.mts",
-    "**/*.config.cts"
+    "**/*.config.cts",
+    "scripts/**/*.js",
+    "scripts/**/*.mjs",
+    "scripts/**/*.cjs"
   ],
   "compilerOptions": {
     /* Modules */


### PR DESCRIPTION
This pull request makes a minor update to the `scripts/clang-format.js` script. The change ensures that the `readdirSync` function is called with an explicit `'utf8'` encoding when reading directories, which can help prevent potential issues with non-UTF-8 filenames.

* Added the `{ encoding: 'utf8' }` option to `readdirSync` calls for both `apps` and `archives` directories in `scripts/clang-format.js`.