### PR TITLE
chore(*): remove unused type declarations from multiple tsconfig files

### DIFF
--- a/apps/blog/tsconfig.json
+++ b/apps/blog/tsconfig.json
@@ -31,7 +31,7 @@
     },
     "resolveJsonModule": true,
     "rootDirs": ["./src", "./.next/types"],
-    "types": ["@lumir/types/global", "node", "react", "react-dom", "webpack-env"],
+    "types": ["@lumir/types/global", "node", "webpack-env"],
 
     /* Emit */
     "noEmit": true,

--- a/apps/moing/tsconfig.json
+++ b/apps/moing/tsconfig.json
@@ -31,7 +31,7 @@
     "paths": {
       "@/*": ["./src/*"] // Map the '@' alias to the 'src' directory.
     },
-    "types": ["@lumir/types/global", "vite/client"],
+    "types": ["@lumir/types/global", "node", "vite/client"],
 
     /* Emit */
     "noEmit": true,

--- a/apps/moing/tsconfig.json
+++ b/apps/moing/tsconfig.json
@@ -31,7 +31,7 @@
     "paths": {
       "@/*": ["./src/*"] // Map the '@' alias to the 'src' directory.
     },
-    "types": ["@lumir/types/global", "node", "react", "react-dom", "vite/client"],
+    "types": ["@lumir/types/global", "vite/client"],
 
     /* Emit */
     "noEmit": true,

--- a/packages/react-kit/tsconfig.json
+++ b/packages/react-kit/tsconfig.json
@@ -24,7 +24,7 @@
   "compilerOptions": {
     /* Modules */
     "rootDir": "./src",
-    "types": ["react", "react-dom"],
+    "types": [],
 
     /* Emit */
     "emitDeclarationOnly": false,

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -28,7 +28,7 @@
     "paths": {
       "@/*": ["./src/*"] // Map the '@' alias to the 'src' directory.
     },
-    "types": ["@lumir/types/global", "node", "react", "react-dom", "vite/client"],
+    "types": ["@lumir/types/global", "vite/client"],
 
     /* Emit */
     "noEmit": true,


### PR DESCRIPTION
This pull request updates TypeScript configuration files across multiple projects to streamline and standardize the global type definitions. The main change is the removal of explicit `react` and `react-dom` type references from the `types` arrays in several `tsconfig.json` files, which helps prevent potential type conflicts and encourages reliance on project-level or package-level type resolution.

TypeScript configuration updates:

* Removed `react` and `react-dom` from the `types` array in `apps/blog/tsconfig.json` and `apps/moing/tsconfig.json` to reduce unnecessary global type inclusions. [[1]](diffhunk://#diff-c05c1c2f5f4c003cb83c78f854d06df24e08ec3d2dcfdbc554fea4f933abc5f1L34-R34) [[2]](diffhunk://#diff-ad5ae4e30879cb32996f605a6cd4da83784338d345741157fc7507b576ef457eL34-R34)
* Removed `react` and `react-dom` from the `types` array in `playground/tsconfig.json` for consistency with other projects.
* Cleared the `types` array in `packages/react-kit/tsconfig.json`, removing `react` and `react-dom` to avoid global type leakage from the library package.