### PR TITLE
fix(@lumir/react-kit): prevent typewriter callbacks from resetting delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2123,9 +2123,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,9 +2140,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,9 +2157,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2183,9 +2174,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,9 +2191,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2223,9 +2208,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9450,6 +9432,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -12484,10 +12467,10 @@
         "vitest-browser-react": "^2.2.0"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -12543,6 +12526,7 @@
     },
     "playground": {
       "dependencies": {
+        "@lumir/react-kit": "*",
         "@lumir/styles": "*",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -37,10 +37,10 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/react-kit/src/hooks/use-typewriter.test.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.test.ts
@@ -543,6 +543,69 @@ describe('use-typewriter', () => {
     assert.strictEqual(onWriteComplete.mock.calls.length, 1);
   });
 
+  it('`onWriteComplete`: should not restart `writePostDelay` when `onWriteComplete` changes (related to `useEffectEvent`)', async () => {
+    // This test verifies `useEffectEvent` behavior because, without it,
+    // changing `onWriteComplete` would first run the effect cleanup, then
+    // rerun the effect, and finally schedule the `setTimeoutRaf` timer again
+    // for the full `writePostDelay`.
+
+    const onWriteComplete1 = vi.fn();
+    const onWriteComplete2 = vi.fn();
+
+    const { act, rerender, result } = await renderHook(
+      (props?: { onWriteComplete: () => void }) =>
+        useTypewriter({
+          text: 'A',
+          mode: 'write',
+          writeSpeed: RAF_FRAME_DURATION_MS,
+          writePreDelay: RAF_FRAME_DURATION_MS,
+          writePostDelay: RAF_FRAME_DURATION_MS * 3,
+          onWriteComplete: props?.onWriteComplete,
+        }),
+      {
+        initialProps: { onWriteComplete: onWriteComplete1 },
+      },
+    );
+
+    const [firstText] = result.current;
+
+    assert.strictEqual(firstText, '');
+    assert.strictEqual(onWriteComplete1.mock.calls.length, 0);
+    assert.strictEqual(onWriteComplete2.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    const [secondText] = result.current;
+
+    assert.strictEqual(secondText, 'A');
+    assert.strictEqual(onWriteComplete1.mock.calls.length, 0);
+    assert.strictEqual(onWriteComplete2.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    const [thirdText] = result.current;
+
+    assert.strictEqual(thirdText, 'A');
+    assert.strictEqual(onWriteComplete1.mock.calls.length, 0);
+    assert.strictEqual(onWriteComplete2.mock.calls.length, 0);
+
+    await rerender({ onWriteComplete: onWriteComplete2 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS * 2);
+    });
+
+    const [fourthText] = result.current;
+
+    assert.strictEqual(fourthText, 'A');
+    assert.strictEqual(onWriteComplete1.mock.calls.length, 0);
+    assert.strictEqual(onWriteComplete2.mock.calls.length, 1);
+  });
+
   it('`onEraseComplete`: should call `onEraseComplete` after erasing completes', async () => {
     const onEraseComplete = vi.fn();
 
@@ -588,5 +651,68 @@ describe('use-typewriter', () => {
 
     assert.strictEqual(fourthText, '');
     assert.strictEqual(onEraseComplete.mock.calls.length, 1);
+  });
+
+  it('`onEraseComplete`: should not restart `erasePostDelay` when `onEraseComplete` changes (related to `useEffectEvent`)', async () => {
+    // This test verifies `useEffectEvent` behavior because, without it,
+    // changing `onEraseComplete` would first run the effect cleanup, then
+    // rerun the effect, and finally schedule the `setTimeoutRaf` timer again
+    // for the full `erasePostDelay`.
+
+    const onEraseComplete1 = vi.fn();
+    const onEraseComplete2 = vi.fn();
+
+    const { act, rerender, result } = await renderHook(
+      (props?: { onEraseComplete: () => void }) =>
+        useTypewriter({
+          text: 'A',
+          mode: 'erase',
+          eraseSpeed: RAF_FRAME_DURATION_MS,
+          erasePreDelay: RAF_FRAME_DURATION_MS,
+          erasePostDelay: RAF_FRAME_DURATION_MS * 3,
+          onEraseComplete: props?.onEraseComplete,
+        }),
+      {
+        initialProps: { onEraseComplete: onEraseComplete1 },
+      },
+    );
+
+    const [firstText] = result.current;
+
+    assert.strictEqual(firstText, 'A');
+    assert.strictEqual(onEraseComplete1.mock.calls.length, 0);
+    assert.strictEqual(onEraseComplete2.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    const [secondText] = result.current;
+
+    assert.strictEqual(secondText, '');
+    assert.strictEqual(onEraseComplete1.mock.calls.length, 0);
+    assert.strictEqual(onEraseComplete2.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    const [thirdText] = result.current;
+
+    assert.strictEqual(thirdText, '');
+    assert.strictEqual(onEraseComplete1.mock.calls.length, 0);
+    assert.strictEqual(onEraseComplete2.mock.calls.length, 0);
+
+    await rerender({ onEraseComplete: onEraseComplete2 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS * 2);
+    });
+
+    const [fourthText] = result.current;
+
+    assert.strictEqual(fourthText, '');
+    assert.strictEqual(onEraseComplete1.mock.calls.length, 0);
+    assert.strictEqual(onEraseComplete2.mock.calls.length, 1);
   });
 });

--- a/packages/react-kit/src/hooks/use-typewriter.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.ts
@@ -6,7 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useRef, useState } from 'react';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -138,17 +138,18 @@ export function useTypewriter({
   erasePostDelay = 1_500,
   loop = false,
   pause = false,
-  onWriteComplete = undefined,
-  onEraseComplete = undefined,
+  onWriteComplete: onWriteCompleteProp = undefined,
+  onEraseComplete: onEraseCompleteProp = undefined,
 }: UseTypewriterOptions): readonly [currentText: string] {
-  const [currentText, setCurrentText] = useState<string>(() => {
-    if (mode === 'write') {
-      return '';
-    } else {
-      return text;
-    }
-  });
+  const [currentText, setCurrentText] = useState<string>(mode === 'write' ? '' : text);
   const [currentMode, setCurrentMode] = useState<Mode>(mode);
+
+  const onWriteComplete = useEffectEvent(() => {
+    onWriteCompleteProp?.();
+  });
+  const onEraseComplete = useEffectEvent(() => {
+    onEraseCompleteProp?.();
+  });
 
   const rafRef = useRef<number | null>(null);
 
@@ -181,7 +182,7 @@ export function useTypewriter({
             setCurrentMode('erase');
           }
 
-          onWriteComplete?.();
+          onWriteComplete();
         }, writePostDelay);
       } else {
         setTimeoutRaf(
@@ -198,7 +199,7 @@ export function useTypewriter({
             setCurrentMode('write');
           }
 
-          onEraseComplete?.();
+          onEraseComplete();
         }, erasePostDelay);
       } else {
         setTimeoutRaf(
@@ -226,8 +227,6 @@ export function useTypewriter({
     erasePostDelay,
     loop,
     pause,
-    onWriteComplete,
-    onEraseComplete,
     currentText,
     currentMode,
   ]);

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,6 +6,7 @@
     "dev": "vite dev"
   },
   "dependencies": {
+    "@lumir/react-kit": "*",
     "@lumir/styles": "*",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"


### PR DESCRIPTION
This pull request improves the `useTypewriter` React hook by ensuring that changes to the `onWriteComplete` and `onEraseComplete` callbacks do not inadvertently restart their respective post-delay timers. This is achieved by leveraging React's `useEffectEvent` to maintain stable callback references. Additionally, new tests are added to verify this behavior, and peer dependencies are updated for better compatibility.

**Enhancements to `useTypewriter` hook:**

* Refactored `useTypewriter` to use `useEffectEvent` for `onWriteComplete` and `onEraseComplete`, preventing unnecessary timer resets when these callbacks change. [[1]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L9-R9) [[2]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L141-R153) [[3]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L184-R185) [[4]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L201-R202) [[5]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L229-L230)

**Testing improvements:**

* Added tests to ensure that updating `onWriteComplete` or `onEraseComplete` does not restart the respective post-delay timers, confirming correct usage of `useEffectEvent`. [[1]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924R546-R608) [[2]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924R655-R717)

**Dependency updates:**

* Updated peer dependencies in `react-kit/package.json` to require React and type definitions version `^19.2.0` for improved compatibility.
* Added `@lumir/react-kit` as a dependency in the `playground` package for local development and testing.