### PR TITLE
fix(*): mark packages as side effect free

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -3,6 +3,7 @@
   "name": "@lumir/react-kit",
   "version": "0.0.0-private",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     "./components": {
       "types": "./build/components/index.d.ts",

--- a/packages/react-kit/src/index.test.ts
+++ b/packages/react-kit/src/index.test.ts
@@ -7,7 +7,6 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import { cn, frontmatter, frontmatterData } from './index.js';
 import packageJson from '../package.json' with { type: 'json' };
 
 // --------------------------------------------------------------------------------
@@ -18,23 +17,6 @@ describe('index', () => {
   describe('package.json', () => {
     it('should have `sideEffects: false`', () => {
       assert.strictEqual(packageJson.sideEffects, false);
-    });
-  });
-
-  describe('exports', () => {
-    it('`cn` should be defined', () => {
-      assert.isDefined(cn);
-      assert.strictEqual(typeof cn, 'function');
-    });
-
-    it('`frontmatter` should be defined', () => {
-      assert.isDefined(frontmatter);
-      assert.strictEqual(typeof frontmatter, 'function');
-    });
-
-    it('`frontmatterData` should be defined', () => {
-      assert.isDefined(frontmatterData);
-      assert.strictEqual(typeof frontmatterData, 'function');
     });
   });
 });

--- a/packages/rehype-plugins/package.json
+++ b/packages/rehype-plugins/package.json
@@ -3,6 +3,7 @@
   "name": "@lumir/rehype-plugins",
   "version": "0.0.0-private",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./build/index.d.ts",

--- a/packages/rehype-plugins/src/index.test.ts
+++ b/packages/rehype-plugins/src/index.test.ts
@@ -8,12 +8,19 @@
 
 import { assert, describe, it } from 'vitest';
 import { rehypeImageLazyLoading, rehypeImageUrlReplace } from './index.js';
+import packageJson from '../package.json' with { type: 'json' };
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 describe('index', () => {
+  describe('package.json', () => {
+    it('should have `sideEffects: false`', () => {
+      assert.strictEqual(packageJson.sideEffects, false);
+    });
+  });
+
   describe('exports', () => {
     it('`rehypeImageLazyLoading` should be defined', () => {
       assert.isDefined(rehypeImageLazyLoading);

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -3,6 +3,7 @@
   "name": "@lumir/remark-plugins",
   "version": "0.0.0-private",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./build/index.d.ts",

--- a/packages/remark-plugins/src/index.test.ts
+++ b/packages/remark-plugins/src/index.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import { cn, frontmatter, frontmatterData } from './index.js';
+import { remarkHeadingFromTitle } from './index.js';
 import packageJson from '../package.json' with { type: 'json' };
 
 // --------------------------------------------------------------------------------
@@ -22,19 +22,9 @@ describe('index', () => {
   });
 
   describe('exports', () => {
-    it('`cn` should be defined', () => {
-      assert.isDefined(cn);
-      assert.strictEqual(typeof cn, 'function');
-    });
-
-    it('`frontmatter` should be defined', () => {
-      assert.isDefined(frontmatter);
-      assert.strictEqual(typeof frontmatter, 'function');
-    });
-
-    it('`frontmatterData` should be defined', () => {
-      assert.isDefined(frontmatterData);
-      assert.strictEqual(typeof frontmatterData, 'function');
+    it('`remarkHeadingFromTitle` should be defined', () => {
+      assert.isDefined(remarkHeadingFromTitle);
+      assert.strictEqual(typeof remarkHeadingFromTitle, 'function');
     });
   });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,6 +3,7 @@
   "name": "@lumir/utils",
   "version": "0.0.0-private",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./build/index.d.ts",


### PR DESCRIPTION
## summary
- Mark @lumir/react-kit, @lumir/rehype-plugins, @lumir/remark-plugins, and @lumir/utils as side effect free for bundlers.
- Add or extend index tests to assert the package metadata and exports.

## scope
- packages/react-kit
- packages/rehype-plugins
- packages/remark-plugins
- packages/utils

## validation
- Not run (per request).

## notes
- Opened as a ready-for-review PR, not a draft.