### PR TITLE
ci(*): add `--prefer-offline` flag to `npm ci`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: node --run build:pkg
@@ -54,7 +54,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Install playwright browsers
         run: npx playwright install chromium --with-deps --only-shell

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           cache: npm # https://github.com/actions/setup-node#caching-global-packages-data
 
       - name: Install dependencies
-        run: npm ci --no-audit --no-fund
+        run: npm ci --no-audit --no-fund --prefer-offline
 
       - name: Build
         run: node --run build:m

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -2,7 +2,7 @@
   "buildCommand": "node --run count-docs && node --run build",
   "framework": "nextjs",
   "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
-  "installCommand": "npm install --prefix ../.. --no-audit --no-fund --prefer-offline",
+  "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ../..",
   "outputDirectory": ".next",
   "regions": ["icn1"]
 }

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -2,7 +2,7 @@
   "buildCommand": "node --run count-docs && node --run build",
   "framework": "nextjs",
   "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
-  "installCommand": "npm install --prefix ../.. --no-audit --no-fund",
+  "installCommand": "npm install --prefix ../.. --no-audit --no-fund --prefer-offline",
   "outputDirectory": ".next",
   "regions": ["icn1"]
 }


### PR DESCRIPTION
This pull request focuses on improving the reliability and speed of dependency installation across CI, deployment, and Vercel build workflows by adding the `--prefer-offline` flag to all relevant `npm install` and `npm ci` commands. This flag helps npm use cached packages when possible, reducing network dependency and potentially speeding up builds.

**Workflow improvements:**

* Updated the `npm ci` commands in the `.github/workflows/ci.yml` and `.github/workflows/deploy.yml` files to include the `--prefer-offline` flag, which encourages npm to use cached dependencies and improves CI reliability and performance. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL35-R35) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL57-R57) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L43-R43)
* Updated the `installCommand` in `apps/blog/vercel.json` to include `--prefer-offline`, optimizing dependency installation during Vercel builds.