### PR TITLE
chore(blog): enable typecheck for test files

### DIFF
--- a/apps/blog/tsconfig.json
+++ b/apps/blog/tsconfig.json
@@ -3,6 +3,9 @@
   "references": [
     {
       "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.test.json"
     }
   ],
   "compilerOptions": {

--- a/apps/blog/tsconfig.test.json
+++ b/apps/blog/tsconfig.test.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../tsconfig.base.test.json",
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "../../packages/react-kit/tsconfig.build.json"
+    },
+    {
+      "path": "../../packages/rehype-plugins/tsconfig.build.json"
+    },
+    {
+      "path": "../../packages/remark-plugins/tsconfig.build.json"
+    },
+    {
+      "path": "../../packages/utils/tsconfig.build.json"
+    }
+  ],
+  "compilerOptions": {
+    /* Modules */
+    "paths": {
+      "@/*": ["./src/*"] // Map the '@' alias to the 'src' directory.
+    },
+
+    /* Language and Environment */
+    "jsx": "react-jsx"
+  }
+}

--- a/tsconfig.base.app.json
+++ b/tsconfig.base.app.json
@@ -27,7 +27,7 @@
     "moduleResolution": "bundler",
 
     /* Emit */
-    "noEmit": true,
+    "outDir": "${configDir}/.tsbuildinfo",
 
     /* Language and Environment */
     "jsx": "react-jsx",


### PR DESCRIPTION
This pull request introduces improvements to TypeScript configuration for the `apps/blog` project, primarily to better support testing and project references. The main changes include adding a dedicated `tsconfig.test.json` for test builds, updating project references, and adjusting the output directory for build artifacts.

TypeScript configuration improvements:

* Added a new `tsconfig.test.json` in `apps/blog` that extends the base test config and references application and package build configs, enabling better modularity and type safety in tests.
* Updated `apps/blog/tsconfig.json` to reference the new `tsconfig.test.json`, ensuring the project is aware of its test configuration.

Build output adjustments:

* Changed `noEmit` to an explicit `outDir` in `tsconfig.base.app.json`, so build artifacts are now emitted to a `.tsbuildinfo` directory, supporting incremental builds and tooling.