### PR TITLE
feat(blog): add `rehype-slug` for GitHub-style heading IDs

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -37,6 +37,7 @@
     "rehype-github-emoji": "^1.0.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
     "rehype-starry-night": "^2.2.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",

--- a/apps/blog/src/utils/markdown-to-html.test.ts
+++ b/apps/blog/src/utils/markdown-to-html.test.ts
@@ -124,7 +124,7 @@ describe('markdown-to-html', () => {
 
     it('should add an H1 heading when `title` option is provided', async () => {
       const markdown = 'Foo Bar Baz';
-      const html = '<h1>Awesome Title</h1>\n<p>Foo Bar Baz</p>';
+      const html = '<h1 id="awesome-title">Awesome Title</h1>\n<p>Foo Bar Baz</p>';
 
       assert.strictEqual(
         await markdownToHtml(markdown, { title: 'Awesome Title' }),
@@ -163,6 +163,36 @@ describe('markdown-to-html', () => {
       const html = '<p>I love this! 👍</p>';
 
       assert.strictEqual(await markdownToHtml(markdown), html);
+    });
+
+    it('should add GitHub-style IDs to Markdown headings', async () => {
+      const markdown = '# Awesome Title\n\n## Usage Guide';
+      const html =
+        '<h1 id="awesome-title">Awesome Title</h1>\n<h2 id="usage-guide">Usage Guide</h2>';
+
+      assert.strictEqual(await markdownToHtml(markdown), html);
+    });
+
+    it('should add unique GitHub-style IDs to duplicate Markdown headings', async () => {
+      const markdown = '# Repeat\n\n# Repeat';
+      const html = '<h1 id="repeat">Repeat</h1>\n<h1 id="repeat-1">Repeat</h1>';
+
+      assert.strictEqual(await markdownToHtml(markdown), html);
+    });
+
+    it('should add GitHub-style IDs to raw HTML headings', async () => {
+      const markdown = '<h2>Raw HTML Heading</h2>';
+      const html = '<h2 id="raw-html-heading">Raw HTML Heading</h2>';
+
+      assert.strictEqual(await markdownToHtml(markdown), html);
+    });
+
+    it('should generate heading IDs before rendering math with KaTeX', async () => {
+      const markdown = '# Area $A$';
+      const html = await markdownToHtml(markdown);
+
+      assert.include(html, '<h1 id="area-a">Area <span class="katex">');
+      assert.notInclude(html, 'id="area-aaa"');
     });
 
     it('should add `loading="lazy"` to `<img>` tags', async () => {

--- a/apps/blog/src/utils/markdown-to-html.ts
+++ b/apps/blog/src/utils/markdown-to-html.ts
@@ -9,6 +9,7 @@
  * @see https://github.com/rehypejs/rehype-github/tree/main/packages/alert#rehype-github-alert (`rehype-github-alert`)
  * @see https://github.com/rehypejs/rehype-github/tree/main/packages/color#rehype-github-color (`rehype-github-color`)
  * @see https://github.com/rehypejs/rehype-github/tree/main/packages/emoji#rehype-github-emoji (`rehype-github-emoji`)
+ * @see https://github.com/rehypejs/rehype-slug#rehype-slug (`rehype-slug`)
  * @see https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex#rehype-katex (`rehype-katex`)
  * @see https://github.com/rehypejs/rehype-starry-night (`rehype-starry-night`)
  * @see https://github.com/rehypejs/rehype/tree/main/packages/rehype-stringify#rehype-stringify (`rehype-stringify`)
@@ -30,6 +31,7 @@ import rehypeRaw from 'rehype-raw';
 import rehypeGitHubAlert from 'rehype-github-alert';
 import rehypeGitHubColor from 'rehype-github-color';
 import rehypeGitHubEmoji from 'rehype-github-emoji';
+import rehypeSlug from 'rehype-slug';
 import rehypeKatex from 'rehype-katex';
 import rehypeStarryNight from 'rehype-starry-night';
 import rehypeStringify from 'rehype-stringify';
@@ -83,6 +85,7 @@ export async function markdownToHtml(
     .use(rehypeGitHubAlert)
     .use(rehypeGitHubColor)
     .use(rehypeGitHubEmoji)
+    .use(rehypeSlug) // Should be used before `rehype-katex` to ensure that heading IDs are generated correctly.
     .use(rehypeKatex)
     .use(rehypeStarryNight)
     .use(rehypeImageLazyLoading)

--- a/apps/blog/src/utils/markdown-to-html.ts
+++ b/apps/blog/src/utils/markdown-to-html.ts
@@ -66,7 +66,7 @@ interface MarkdownToHtmlOptions {
  *
  * console.log(html);
  * // Output:
- * // <h1>Awesome Title</h1>
+ * // <h1 id="awesome-title">Awesome Title</h1>
  * // <p>Foo Bar Baz</p>
  * ```
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "rehype-github-emoji": "^1.0.0",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
+        "rehype-slug": "^6.0.0",
         "rehype-starry-night": "^2.2.0",
         "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
@@ -5716,7 +5717,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/glob-parent": {
@@ -6108,6 +6108,19 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
@@ -9999,6 +10012,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
This pull request enhances the Markdown-to-HTML conversion in the blog app by adding automatic, GitHub-style IDs to all headings, improving navigation and accessibility. It introduces the `rehype-slug` plugin to generate these IDs, updates dependencies, and adds comprehensive tests to verify the new behavior.

**Markdown heading ID generation:**

* Added the `rehype-slug` plugin to the Markdown processing pipeline in `markdown-to-html.ts`, ensuring all headings (including raw HTML headings and duplicates) receive unique, GitHub-style IDs. The plugin is applied before `rehype-katex` to maintain correct ID generation with math rendering. [[1]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872R34) [[2]](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171R40) [[3]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872R88)
* Updated documentation/comments in `markdown-to-html.ts` to reference the new `rehype-slug` plugin.

**Testing improvements:**

* Added and updated tests in `markdown-to-html.test.ts` to verify that headings receive correct and unique IDs, including for duplicate headings, raw HTML headings, and headings containing math. [[1]](diffhunk://#diff-2e026be3d590e880e478169b3f8106ba6b6369e81f8772d26d70bd2358a2bc4bL127-R127) [[2]](diffhunk://#diff-2e026be3d590e880e478169b3f8106ba6b6369e81f8772d26d70bd2358a2bc4bR168-R197)