### PR TITLE
feat(blog): add `rehype-autolink-headings` for GitHub-style heading links

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -32,6 +32,7 @@
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "rehype-autolink-headings": "^7.1.0",
     "rehype-github-alert": "^1.0.0",
     "rehype-github-color": "^1.0.0",
     "rehype-github-emoji": "^1.0.0",

--- a/apps/blog/src/components/layouts/article.module.css
+++ b/apps/blog/src/components/layouts/article.module.css
@@ -3,7 +3,7 @@
   width: 100%;
   min-width: 200px;
   max-width: 980px;
-  padding: var(--size-article-padding-large) var(--size-article-padding-small);
+  padding: var(--size-article-padding-large) var(--size-article-padding-medium);
   margin: 0 auto;
 
   @media (width >= 1024px) {

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -276,7 +276,7 @@
     &:is(:hover, :focus-within) > a[aria-hidden='true'][href^='#'] .icon-link {
       visibility: visible;
 
-      &:before {
+      &::before {
         width: 20px;
         height: 20px;
         content: ' ';

--- a/apps/blog/src/styles/markdown.css
+++ b/apps/blog/src/styles/markdown.css
@@ -26,7 +26,7 @@
     & :is(h1, h2, h3, h4, h5, h6) {
       display: inline-block;
 
-      & .anchor {
+      & > a[aria-hidden='true'][href^='#'] {
         margin-left: -40px;
       }
     }
@@ -55,14 +55,6 @@
 
   & dfn {
     font-style: italic;
-  }
-
-  & h1 {
-    margin: 0.67em 0;
-    font-weight: var(--text-weight-semibold);
-    padding-bottom: 0.3em;
-    font-size: 2em;
-    border-bottom: 1px solid var(--color-border-muted);
   }
 
   /* custom */
@@ -254,22 +246,65 @@
     box-shadow: inset 0 -1px 0 var(--color-border-neutral-muted);
   }
 
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
+  /* #region h1, h2, h3, h4, h5, h6 */
+
+  & :is(h1, h2, h3, h4, h5, h6) {
+    /* Keep linked headings visible below the sticky header. */
+    scroll-margin-top: calc(var(--size-header-height) + var(--size-16));
     margin-top: var(--size-24);
     margin-bottom: var(--size-16);
     font-weight: var(--text-weight-semibold);
     line-height: 1.25;
+
+    & .icon-link {
+      color: var(--color-fg-default);
+      vertical-align: baseline;
+      visibility: hidden;
+    }
+
+    & > a[aria-hidden='true'][href^='#'] {
+      float: left;
+      padding-right: var(--size-4);
+      margin-left: -24px;
+      text-decoration: none;
+
+      &:focus {
+        outline: none;
+      }
+    }
+
+    &:is(:hover, :focus-within) > a[aria-hidden='true'][href^='#'] .icon-link {
+      visibility: visible;
+
+      &:before {
+        width: 20px;
+        height: 20px;
+        content: ' ';
+        display: inline-block;
+        background-color: currentColor;
+        -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+        mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+      }
+    }
+
+    & :is(tt, code) {
+      padding: 0 0.2em;
+      font-size: inherit;
+    }
+  }
+
+  & h1 {
+    margin: 0.67em 0;
+    font-weight: var(--text-weight-semibold);
+    font-size: 2em;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid var(--color-border-muted);
   }
 
   & h2 {
     font-weight: var(--text-weight-semibold);
-    padding-bottom: 0.3em;
     font-size: 1.5em;
+    padding-bottom: 0.3em;
     border-bottom: 1px solid var(--color-border-muted);
   }
 
@@ -293,6 +328,8 @@
     font-size: 0.85em;
     color: var(--color-fg-muted);
   }
+
+  /* #endregion h1, h2, h3, h4, h5, h6 */
 
   & p {
     margin-top: 0;
@@ -386,17 +423,6 @@
     color: var(--color-fg-danger);
   }
 
-  & .anchor {
-    float: left;
-    padding-right: var(--size-4);
-    margin-left: -20px;
-    line-height: 1;
-  }
-
-  & .anchor:focus {
-    outline: none;
-  }
-
   & p,
   & blockquote,
   & ul,
@@ -415,37 +441,6 @@
 
   & blockquote > :last-child {
     margin-bottom: 0;
-  }
-
-  & :is(h1, h2, h3, h4, h5, h6) {
-    & .octicon-link {
-      color: var(--color-fg-default);
-      vertical-align: middle;
-      visibility: hidden;
-    }
-
-    &:hover .anchor {
-      text-decoration: none;
-
-      & .octicon-link {
-        visibility: visible;
-
-        &:before {
-          width: 16px;
-          height: 16px;
-          content: ' ';
-          display: inline-block;
-          background-color: currentColor;
-          -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-          mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
-        }
-      }
-    }
-
-    & :is(tt, code) {
-      padding: 0 0.2em;
-      font-size: inherit;
-    }
   }
 
   & :is(ul, ol).no-list {

--- a/apps/blog/src/styles/variables.css
+++ b/apps/blog/src/styles/variables.css
@@ -23,6 +23,7 @@
   --size-sidebar-width: 256px;
   --size-nav-width: var(--size-sidebar-width);
   --size-article-padding-large: 45px;
+  --size-article-padding-medium: 24px;
   --size-article-padding-small: 12px;
   --size-letter-spacing-large: -1.5px;
   --size-letter-spacing-medium: -1px;

--- a/apps/blog/src/utils/markdown-to-html.test.ts
+++ b/apps/blog/src/utils/markdown-to-html.test.ts
@@ -124,7 +124,8 @@ describe('markdown-to-html', () => {
 
     it('should add an H1 heading when `title` option is provided', async () => {
       const markdown = 'Foo Bar Baz';
-      const html = '<h1 id="awesome-title">Awesome Title</h1>\n<p>Foo Bar Baz</p>';
+      const html =
+        '<h1 id="awesome-title"><a aria-hidden="true" tabindex="-1" href="#awesome-title"><span class="icon-link"></span></a>Awesome Title</h1>\n<p>Foo Bar Baz</p>';
 
       assert.strictEqual(
         await markdownToHtml(markdown, { title: 'Awesome Title' }),
@@ -165,24 +166,65 @@ describe('markdown-to-html', () => {
       assert.strictEqual(await markdownToHtml(markdown), html);
     });
 
-    it('should add GitHub-style IDs to Markdown headings', async () => {
+    it('should add GitHub-style IDs and self-link anchors to Markdown headings', async () => {
       const markdown = '# Awesome Title\n\n## Usage Guide';
       const html =
-        '<h1 id="awesome-title">Awesome Title</h1>\n<h2 id="usage-guide">Usage Guide</h2>';
+        '<h1 id="awesome-title"><a aria-hidden="true" tabindex="-1" href="#awesome-title"><span class="icon-link"></span></a>Awesome Title</h1>\n<h2 id="usage-guide"><a aria-hidden="true" tabindex="-1" href="#usage-guide"><span class="icon-link"></span></a>Usage Guide</h2>';
 
       assert.strictEqual(await markdownToHtml(markdown), html);
     });
 
-    it('should add unique GitHub-style IDs to duplicate Markdown headings', async () => {
+    it('should add self-link anchors to every Markdown heading level', async () => {
+      const markdown =
+        '# Heading 1\n\n## Heading 2\n\n### Heading 3\n\n#### Heading 4\n\n##### Heading 5\n\n###### Heading 6';
+      const html = await markdownToHtml(markdown);
+
+      assert.include(
+        html,
+        '<h1 id="heading-1"><a aria-hidden="true" tabindex="-1" href="#heading-1"><span class="icon-link"></span></a>Heading 1</h1>',
+      );
+      assert.include(
+        html,
+        '<h2 id="heading-2"><a aria-hidden="true" tabindex="-1" href="#heading-2"><span class="icon-link"></span></a>Heading 2</h2>',
+      );
+      assert.include(
+        html,
+        '<h3 id="heading-3"><a aria-hidden="true" tabindex="-1" href="#heading-3"><span class="icon-link"></span></a>Heading 3</h3>',
+      );
+      assert.include(
+        html,
+        '<h4 id="heading-4"><a aria-hidden="true" tabindex="-1" href="#heading-4"><span class="icon-link"></span></a>Heading 4</h4>',
+      );
+      assert.include(
+        html,
+        '<h5 id="heading-5"><a aria-hidden="true" tabindex="-1" href="#heading-5"><span class="icon-link"></span></a>Heading 5</h5>',
+      );
+      assert.include(
+        html,
+        '<h6 id="heading-6"><a aria-hidden="true" tabindex="-1" href="#heading-6"><span class="icon-link"></span></a>Heading 6</h6>',
+      );
+    });
+
+    it('should add unique GitHub-style IDs and self-link anchors to duplicate Markdown headings', async () => {
       const markdown = '# Repeat\n\n# Repeat';
-      const html = '<h1 id="repeat">Repeat</h1>\n<h1 id="repeat-1">Repeat</h1>';
+      const html =
+        '<h1 id="repeat"><a aria-hidden="true" tabindex="-1" href="#repeat"><span class="icon-link"></span></a>Repeat</h1>\n<h1 id="repeat-1"><a aria-hidden="true" tabindex="-1" href="#repeat-1"><span class="icon-link"></span></a>Repeat</h1>';
 
       assert.strictEqual(await markdownToHtml(markdown), html);
     });
 
-    it('should add GitHub-style IDs to raw HTML headings', async () => {
+    it('should add GitHub-style IDs and self-link anchors to raw HTML headings', async () => {
       const markdown = '<h2>Raw HTML Heading</h2>';
-      const html = '<h2 id="raw-html-heading">Raw HTML Heading</h2>';
+      const html =
+        '<h2 id="raw-html-heading"><a aria-hidden="true" tabindex="-1" href="#raw-html-heading"><span class="icon-link"></span></a>Raw HTML Heading</h2>';
+
+      assert.strictEqual(await markdownToHtml(markdown), html);
+    });
+
+    it('should preserve explicit raw HTML heading IDs when adding self-link anchors', async () => {
+      const markdown = '<h2 id="custom-heading">Raw HTML Heading</h2>';
+      const html =
+        '<h2 id="custom-heading"><a aria-hidden="true" tabindex="-1" href="#custom-heading"><span class="icon-link"></span></a>Raw HTML Heading</h2>';
 
       assert.strictEqual(await markdownToHtml(markdown), html);
     });
@@ -191,7 +233,10 @@ describe('markdown-to-html', () => {
       const markdown = '# Area $A$';
       const html = await markdownToHtml(markdown);
 
-      assert.include(html, '<h1 id="area-a">Area <span class="katex">');
+      assert.include(
+        html,
+        '<h1 id="area-a"><a aria-hidden="true" tabindex="-1" href="#area-a"><span class="icon-link"></span></a>Area <span class="katex">',
+      );
       assert.notInclude(html, 'id="area-aaa"');
     });
 

--- a/apps/blog/src/utils/markdown-to-html.ts
+++ b/apps/blog/src/utils/markdown-to-html.ts
@@ -10,6 +10,7 @@
  * @see https://github.com/rehypejs/rehype-github/tree/main/packages/color#rehype-github-color (`rehype-github-color`)
  * @see https://github.com/rehypejs/rehype-github/tree/main/packages/emoji#rehype-github-emoji (`rehype-github-emoji`)
  * @see https://github.com/rehypejs/rehype-slug#rehype-slug (`rehype-slug`)
+ * @see https://github.com/rehypejs/rehype-autolink-headings#rehype-autolink-headings (`rehype-autolink-headings`)
  * @see https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex#rehype-katex (`rehype-katex`)
  * @see https://github.com/rehypejs/rehype-starry-night (`rehype-starry-night`)
  * @see https://github.com/rehypejs/rehype/tree/main/packages/rehype-stringify#rehype-stringify (`rehype-stringify`)
@@ -32,6 +33,7 @@ import rehypeGitHubAlert from 'rehype-github-alert';
 import rehypeGitHubColor from 'rehype-github-color';
 import rehypeGitHubEmoji from 'rehype-github-emoji';
 import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeKatex from 'rehype-katex';
 import rehypeStarryNight from 'rehype-starry-night';
 import rehypeStringify from 'rehype-stringify';
@@ -66,7 +68,7 @@ interface MarkdownToHtmlOptions {
  *
  * console.log(html);
  * // Output:
- * // <h1 id="awesome-title">Awesome Title</h1>
+ * // <h1 id="awesome-title"><a aria-hidden="true" tabindex="-1" href="#awesome-title"><span class="icon-link"></span></a>Awesome Title</h1>
  * // <p>Foo Bar Baz</p>
  * ```
  */
@@ -85,7 +87,18 @@ export async function markdownToHtml(
     .use(rehypeGitHubAlert)
     .use(rehypeGitHubColor)
     .use(rehypeGitHubEmoji)
-    .use(rehypeSlug) // Should be used before `rehype-katex` to ensure that heading IDs are generated correctly.
+    .use(rehypeSlug) // Use before `rehype-katex` to ensure heading IDs are generated correctly.
+    .use(
+      rehypeAutolinkHeadings, // Use before `rehype-katex` and after `rehype-slug` to ensure autolink anchors are generated correctly.
+      {
+        content: {
+          type: 'element',
+          tagName: 'span',
+          properties: { className: ['icon-link'] },
+          children: [],
+        },
+      },
+    )
     .use(rehypeKatex)
     .use(rehypeStarryNight)
     .use(rehypeImageLazyLoading)

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "next": "^16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "rehype-autolink-headings": "^7.1.0",
         "rehype-github-alert": "^1.0.0",
         "rehype-github-color": "^1.0.0",
         "rehype-github-emoji": "^1.0.0",
@@ -9903,6 +9904,24 @@
         "rehype-parse": "^9.0.0",
         "rehype-stringify": "^10.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
This pull request enhances the Markdown rendering experience in the blog app by adding GitHub-style self-link anchors to all heading levels, updating the styling for these anchors, and improving overall heading and article layout. The changes also include comprehensive updates to tests, documentation, and CSS to support these new features.

**Markdown heading autolink and ID improvements:**

- Added the `rehype-autolink-headings` plugin to automatically insert GitHub-style self-link anchors (with an icon) to all Markdown and raw HTML headings. This ensures every heading is directly linkable and visually consistent. [[1]](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171R35) [[2]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872R13) [[3]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872R36) [[4]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872L88-R101)
- Updated the `markdownToHtml` utility and its documentation to reflect the new anchor behavior, and added/modified tests to verify that all headings receive unique IDs and self-link anchors, including for duplicate headings and raw HTML headings. [[1]](diffhunk://#diff-8eee24e715342a2f801b2a2c257a6f512694cfaca512ee00fbf19f4626278872L69-R71) [[2]](diffhunk://#diff-2e026be3d590e880e478169b3f8106ba6b6369e81f8772d26d70bd2358a2bc4bL127-R128) [[3]](diffhunk://#diff-2e026be3d590e880e478169b3f8106ba6b6369e81f8772d26d70bd2358a2bc4bL168-R227) [[4]](diffhunk://#diff-2e026be3d590e880e478169b3f8106ba6b6369e81f8772d26d70bd2358a2bc4bL194-R239)

**Styling and layout enhancements:**

- Refactored heading and anchor styles in `markdown.css` to support the new anchor markup, improve visibility, and ensure anchors are only visible on hover/focus. Also improved scroll behavior for headings and updated code styling within headings. [[1]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117L29-R29) [[2]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117L60-L67) [[3]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117L257-R307) [[4]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117R332-R333) [[5]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117L389-L399) [[6]](diffhunk://#diff-8ddbda0fd84aebdd689e97526d9df2d882a04a79aedbe0d5118d466de7135117L420-L450)
- Adjusted article padding for better readability and introduced a new CSS variable for medium padding. [[1]](diffhunk://#diff-65f0dbaae2f66cba3389af9522dff30a0ecd83e4d597d075c6872581b1dc1bf2L6-R6) [[2]](diffhunk://#diff-cbd20b785c3c259210e75440684675108490adc89fe8aacbe1ed44b960b81f2eR26)

These updates collectively modernize the Markdown rendering to be more user-friendly, accessible, and visually aligned with GitHub’s conventions.