### PR TITLE
feat(@lumir/remark-plugins): export `RemarkHeadingFromTitleOptions` and introduce type testing setup

### DIFF
--- a/apps/api/vitest.config.js
+++ b/apps/api/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.test.{js,mjs,cjs,ts,mts,cts}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts}'],

--- a/apps/blog/vitest.config.js
+++ b/apps/blog/vitest.config.js
@@ -12,6 +12,10 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts,tsx}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,15 @@ export default defineConfig([
     },
   },
   {
+    name: 'js/global/test-d',
+    files: ['**/*.test-d.{ts,mts,cts,tsx}'],
+    rules: {
+      'prefer-const': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
+  {
     name: 'js/apps/api',
     files: ['apps/api/**/*.{js,mjs,cjs,ts,mts,cts}'],
     languageOptions: {

--- a/packages/react-kit/tsconfig.test-d.json
+++ b/packages/react-kit/tsconfig.test-d.json
@@ -1,17 +1,14 @@
 {
-  "files": [],
+  "extends": "../../tsconfig.base.test-d.json",
   "references": [
     {
       "path": "./tsconfig.build.json"
-    },
-    {
-      "path": "./tsconfig.test-d.json"
-    },
-    {
-      "path": "./tsconfig.test.json"
     }
   ],
   "compilerOptions": {
+    /* Modules */
+    "types": ["node"],
+
     /* Language and Environment */
     "jsx": "react-jsx"
   }

--- a/packages/react-kit/vitest.config.js
+++ b/packages/react-kit/vitest.config.js
@@ -9,6 +9,10 @@ export default defineConfig({
       instances: [{ browser: 'chromium' }],
     },
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts,tsx}'],

--- a/packages/rehype-plugins/tsconfig.json
+++ b/packages/rehype-plugins/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "./tsconfig.build.json"
     },
     {
+      "path": "./tsconfig.test-d.json"
+    },
+    {
       "path": "./tsconfig.test.json"
     }
   ]

--- a/packages/rehype-plugins/tsconfig.test-d.json
+++ b/packages/rehype-plugins/tsconfig.test-d.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.test-d.json",
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/rehype-plugins/vitest.config.js
+++ b/packages/rehype-plugins/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts,tsx}'],

--- a/packages/remark-plugins/src/remark-heading-from-title.test-d.ts
+++ b/packages/remark-plugins/src/remark-heading-from-title.test-d.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Test for `remark-heading-from-title.ts`
+ * @fileoverview Type test for `remark-heading-from-title.ts`
  */
 
 // --------------------------------------------------------------------------------

--- a/packages/remark-plugins/src/remark-heading-from-title.test-d.ts
+++ b/packages/remark-plugins/src/remark-heading-from-title.test-d.ts
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Test for `remark-heading-from-title.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import {
+  remarkHeadingFromTitle,
+  type RemarkHeadingFromTitleOptions,
+} from './remark-heading-from-title.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region RemarkHeadingFromTitleOptions
+
+let options: RemarkHeadingFromTitleOptions;
+
+options = {};
+options = { title: 'title' };
+options = { title: '' };
+options = { title: undefined };
+
+// @ts-expect-error - `title` should be a string or undefined.
+options = { title: 123 };
+// @ts-expect-error - `title` should be a string or undefined.
+options = { title: null };
+// @ts-expect-error - `unknown` is not a valid property of `RemarkHeadingFromTitleOptions`.
+options = { unknown: 'unknown' };
+
+// #endregion RemarkHeadingFromTitleOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region remarkHeadingFromTitle
+
+({}) as typeof remarkHeadingFromTitle satisfies Function;
+({}) as Parameters<typeof remarkHeadingFromTitle>[0] satisfies
+  | RemarkHeadingFromTitleOptions
+  | undefined;
+({}) as ReturnType<typeof remarkHeadingFromTitle> satisfies Function;
+
+// @ts-expect-error - `remarkHeadingFromTitle` should be a function.
+({}) as typeof remarkHeadingFromTitle satisfies boolean;
+// @ts-expect-error - `remarkHeadingFromTitle` should be a function.
+({}) as typeof remarkHeadingFromTitle satisfies string;
+
+// #endregion remarkHeadingFromTitle
+// --------------------------------------------------------------------------------

--- a/packages/remark-plugins/src/remark-heading-from-title.ts
+++ b/packages/remark-plugins/src/remark-heading-from-title.ts
@@ -10,6 +10,21 @@ import { fromMarkdown } from 'mdast-util-from-markdown';
 import type { Heading, Root } from 'mdast';
 
 // --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Options for the `remarkHeadingFromTitle` plugin.
+ */
+export interface RemarkHeadingFromTitleOptions {
+  /**
+   * The title to generate the H1 heading from.
+   * If not provided or an empty string, the plugin will not prepend any heading.
+   */
+  title?: string | undefined;
+}
+
+// --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
@@ -28,7 +43,7 @@ import type { Heading, Root } from 'mdast';
  * console.log(file.value); // Output: '# title\n\nparagraph'
  * ```
  */
-export function remarkHeadingFromTitle(options?: { title?: string | undefined }) {
+export function remarkHeadingFromTitle(options?: RemarkHeadingFromTitleOptions) {
   const { title } = options ?? {};
 
   if (typeof title !== 'string' || title === '') {

--- a/packages/remark-plugins/tsconfig.json
+++ b/packages/remark-plugins/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "./tsconfig.build.json"
     },
     {
+      "path": "./tsconfig.test-d.json"
+    },
+    {
       "path": "./tsconfig.test.json"
     }
   ]

--- a/packages/remark-plugins/tsconfig.test-d.json
+++ b/packages/remark-plugins/tsconfig.test-d.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.test-d.json",
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/remark-plugins/vitest.config.js
+++ b/packages/remark-plugins/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts,tsx}'],

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -5,6 +5,9 @@
       "path": "./tsconfig.build.json"
     },
     {
+      "path": "./tsconfig.test-d.json"
+    },
+    {
       "path": "./tsconfig.test.json"
     }
   ]

--- a/packages/utils/tsconfig.test-d.json
+++ b/packages/utils/tsconfig.test-d.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.test-d.json",
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    }
+  ]
+}

--- a/packages/utils/vitest.config.js
+++ b/packages/utils/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+
+    // Vitest's built-in type checking is still experimental, so we intentionally keep it disabled.
+    // I prefer the native TypeScript type-checking flow and rely on the repo's project references
+    // for better performance, familiar behavior, and more accurate diagnostics.
     typecheck: {
       enabled: false, // Set to true if you want to enable type checking during tests.
       include: ['src/**/*.test-d.{ts,mts,cts,tsx}'],

--- a/tsconfig.base.app.json
+++ b/tsconfig.base.app.json
@@ -19,6 +19,10 @@
     "${configDir}/src/**/*.test.mts",
     "${configDir}/src/**/*.test.cts",
     "${configDir}/src/**/*.test.tsx",
+    "${configDir}/src/**/*.test-d.ts",
+    "${configDir}/src/**/*.test-d.mts",
+    "${configDir}/src/**/*.test-d.cts",
+    "${configDir}/src/**/*.test-d.tsx",
     "${configDir}/**/fixtures/**"
   ],
   "compilerOptions": {

--- a/tsconfig.base.build.json
+++ b/tsconfig.base.build.json
@@ -19,6 +19,10 @@
     "${configDir}/src/**/*.test.mts",
     "${configDir}/src/**/*.test.cts",
     "${configDir}/src/**/*.test.tsx",
+    "${configDir}/src/**/*.test-d.ts",
+    "${configDir}/src/**/*.test-d.mts",
+    "${configDir}/src/**/*.test-d.cts",
+    "${configDir}/src/**/*.test-d.tsx",
     "${configDir}/**/fixtures/**"
   ],
   "compilerOptions": {

--- a/tsconfig.base.test-d.json
+++ b/tsconfig.base.test-d.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "${configDir}/src/**/*.test-d.ts",
+    "${configDir}/src/**/*.test-d.mts",
+    "${configDir}/src/**/*.test-d.cts",
+    "${configDir}/src/**/*.test-d.tsx"
+  ],
+  "compilerOptions": {
+    /* Type Checking */
+    "noUnusedLocals": false,
+
+    /* Emit */
+    "noEmit": true,
+
+    /* Projects */
+    "tsBuildInfoFile": "${configDir}/.tsbuildinfo/tsconfig.test-d.tsbuildinfo"
+  }
+}


### PR DESCRIPTION
This pull request introduces a new convention and configuration for TypeScript type-only tests (using `*.test-d.ts` files) across the monorepo, alongside improvements to type definitions and test configurations. The main focus is to enable type-level testing in a clean, isolated manner, and to ensure that both ESLint and Vitest are aware of these new files without interfering with existing test or build flows.

**Key changes include:**

### Type-Only Test Infrastructure

* Added new `tsconfig.base.test-d.json` at the root, defining how `*.test-d.ts(x)` files are handled (noEmit, noUnusedLocals, dedicated tsbuildinfo file). Package-level `tsconfig.test-d.json` files were added to extend this base and reference their respective build configs. [[1]](diffhunk://#diff-ef0b33c66882fd8e0bc81f0554de2527ca8f3248e53589f986c3c10bea6098c9R1-R19) [[2]](diffhunk://#diff-972ad6edc40129b1d95b922bd46593f18e0056117286bfa1f0d6da5b75bcc976R7-R9) [[3]](diffhunk://#diff-9a240e06144ab33c98ef340026183a860d49ebdaa40f61c7fbaecd15a5436a3eR7-R9) [[4]](diffhunk://#diff-48978bcb454486242bb5fca617a553ee03150d58d307fc32ad926f697c3179bfR1-R8)
* Updated root build and app tsconfigs to include the new `*.test-d.ts(x)` patterns, ensuring these files are recognized by the TypeScript project references system. [[1]](diffhunk://#diff-2cecf97c69681d6deaaadfc771c6b5ba8745c21a15170965f72aba057db5cdc9R22-R25) [[2]](diffhunk://#diff-7256af36dc29e41e0cb0cb63d9527d0d98f5627c039ca32c2162246b1e4c8327R22-R25)

### Vitest Configuration

* Updated all Vitest configs to document and explicitly disable Vitest's experimental built-in type checking, instead relying on the new native TypeScript type-checking flow for `*.test-d.ts(x)` files. The configs now include a `typecheck` block with these patterns and rationale. [[1]](diffhunk://#diff-e7fea4c11f5f1da70faf1e26aa23ecc599a3172c0803e3cc16dde68ab33bd0e9R6-R9) [[2]](diffhunk://#diff-48262cde35ce384eff89ea67189a3df3999fed2b886d60d3b006247025f4be29R15-R18) [[3]](diffhunk://#diff-b9f65df312b7bf6eb879094e91bd8cb41f50ffa2429969c4b9971961693f80c1R12-R15) [[4]](diffhunk://#diff-86c8424b253a494267889ed6a89ce4c7693663bfd86fff6e6488ee96e079381cR6-R9)

### ESLint Configuration

* Added a new ESLint override for `*.test-d.ts(x)` files, disabling rules that are unnecessary or noisy for type-only tests (e.g., `prefer-const`, `@typescript-eslint/no-unused-vars`).

### remark-heading-from-title Plugin Improvements

* Introduced an explicit `RemarkHeadingFromTitleOptions` interface for the plugin's options, improving type safety and documentation. Updated the plugin to use this interface. [[1]](diffhunk://#diff-7ac7ce222f942f8a2af8af610afb0f15af793264a44b5df05fd27b325c29ead3R12-R26) [[2]](diffhunk://#diff-7ac7ce222f942f8a2af8af610afb0f15af793264a44b5df05fd27b325c29ead3L31-R46)
* Added a new type-only test file, `remark-heading-from-title.test-d.ts`, to verify the plugin's type definitions and ensure correct usage/errors at the type level.