### PR TITLE
refactor(@lumir/remark-plugins): remove `remark` from dev-dependencies to reduce dependency footprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10096,23 +10096,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
-      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "remark-parse": "^11.0.0",
-        "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -12631,9 +12614,9 @@
       "devDependencies": {
         "@types/mdast": "^4.0.4",
         "rehype-stringify": "^10.0.1",
-        "remark": "^15.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
+        "remark-stringify": "^11.0.0",
         "unified": "^11.0.5",
         "vitest": "^4.1.6"
       }

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -30,9 +30,9 @@
   "devDependencies": {
     "@types/mdast": "^4.0.4",
     "rehype-stringify": "^10.0.1",
-    "remark": "^15.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "remark-stringify": "^11.0.0",
     "unified": "^11.0.5",
     "vitest": "^4.1.6"
   }

--- a/packages/remark-plugins/src/remark-custom-heading-id.test.ts
+++ b/packages/remark-plugins/src/remark-custom-heading-id.test.ts
@@ -21,7 +21,7 @@ import { remarkCustomHeadingId } from './remark-custom-heading-id.js';
 /**
  * Processes the given markdown string using the `remark-custom-heading-id` plugin.
  * @param markdown The markdown string to process.
- * @returns A promise that resolves to a VFile whose `value` is the processed HTML.
+ * @returns A promise that resolves to a `VFile` whose `value` is the processed HTML.
  */
 function processMarkdown(markdown: string) {
   return unified()

--- a/packages/remark-plugins/src/remark-heading-from-title.test.ts
+++ b/packages/remark-plugins/src/remark-heading-from-title.test.ts
@@ -6,8 +6,10 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { remark } from 'remark';
 import { assert, describe, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
 import { remarkHeadingFromTitle } from './remark-heading-from-title.js';
 
 // --------------------------------------------------------------------------------
@@ -17,16 +19,20 @@ import { remarkHeadingFromTitle } from './remark-heading-from-title.js';
 describe('remark-heading-from-title', () => {
   describe('when the title is provided', () => {
     it('should prepend an h1 heading to the markdown document', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, { title: 'lumir' })
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, '# lumir\n\nparagraph\n');
     });
 
     it('should preserve markdown syntax inside the title heading', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, { title: '`lumir` **page**' })
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, '# `lumir` **page**\n\nparagraph\n');
@@ -35,49 +41,63 @@ describe('remark-heading-from-title', () => {
 
   describe('when the title is empty', () => {
     it('should keep the original markdown content unchanged when the title is empty', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, { title: '' })
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');
     });
 
     it('should keep the original markdown content unchanged when the option is `null`', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(
           remarkHeadingFromTitle,
           null as unknown as Parameters<typeof remarkHeadingFromTitle>[0],
         )
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');
     });
 
     it('should keep the original markdown content unchanged when the option is `undefined` - 1', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, undefined)
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');
     });
 
     it('should keep the original markdown content unchanged when the option is `undefined` - 2', async () => {
-      const file = await remark().use(remarkHeadingFromTitle).process('paragraph\n');
+      const file = await unified()
+        .use(remarkParse)
+        .use(remarkHeadingFromTitle)
+        .use(remarkStringify)
+        .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');
     });
 
     it('should keep the original markdown content unchanged when the title is `undefined`', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, { title: undefined })
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');
     });
 
     it('should keep the original markdown content unchanged when the title is not a string', async () => {
-      const file = await remark()
+      const file = await unified()
+        .use(remarkParse)
         .use(remarkHeadingFromTitle, { title: 123 as unknown as string })
+        .use(remarkStringify)
         .process('paragraph\n');
 
       assert.strictEqual(file.value, 'paragraph\n');

--- a/packages/remark-plugins/src/remark-heading-from-title.ts
+++ b/packages/remark-plugins/src/remark-heading-from-title.ts
@@ -33,11 +33,15 @@ export interface RemarkHeadingFromTitleOptions {
  * @example
  *
  * ```ts
- * import { remark } from 'remark';
+ * import { unified } from 'unified';
+ * import remarkParse from 'remark-parse';
+ * import remarkStringify from 'remark-stringify';
  * import { remarkHeadingFromTitle } from '@lumir/remark-plugins';
  *
- * const file = await remark()
+ * const file = await unified()
+ *   .use(remarkParse)
  *   .use(remarkHeadingFromTitle, { title: 'title' })
+ *   .use(remarkStringify)
  *   .process('paragraph');
  *
  * console.log(file.value); // Output: '# title\n\nparagraph'


### PR DESCRIPTION
This pull request updates the test and documentation setup for the `remark-heading-from-title` plugin to use the `unified` processor with explicit `remark-parse` and `remark-stringify` plugins, replacing the deprecated direct use of `remark()`. It also updates dependencies to reflect this change.

**Migration to unified processor and explicit plugins:**

* Refactored all tests in `remark-heading-from-title.test.ts` to use `unified()`, `.use(remarkParse)`, and `.use(remarkStringify)` instead of `remark()`, ensuring compatibility with the latest unified ecosystem and improving clarity of the processing pipeline. [[1]](diffhunk://#diff-26387da3580feadb8ef6029b0d95f29fe1cb26bd1ef090add07ecd568f3d463fL9-R12) [[2]](diffhunk://#diff-26387da3580feadb8ef6029b0d95f29fe1cb26bd1ef090add07ecd568f3d463fL20-R35) [[3]](diffhunk://#diff-26387da3580feadb8ef6029b0d95f29fe1cb26bd1ef090add07ecd568f3d463fL38-R100)
* Updated the usage example in the documentation comment of `remark-heading-from-title.ts` to reflect the new recommended approach using `unified`, `remark-parse`, and `remark-stringify`.

**Dependency updates:**

* Removed the `remark` dependency and added `remark-stringify` in `package.json` to align with the new processing approach.

**Minor improvements:**

* Clarified the return type in a test utility function’s JSDoc in `remark-custom-heading-id.test.ts`.