### PR TITLE
refactor(blog): remove `@next/third-parties` and inline Google Analytics compoenent

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -23,7 +23,6 @@
     "@lumir/remark-plugins": "*",
     "@lumir/styles": "*",
     "@lumir/utils": "*",
-    "@next/third-parties": "^16.2.6",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -11,8 +11,8 @@ import { type PropsWithChildren } from 'react';
 
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import { GoogleAnalytics } from '@next/third-parties/google';
 
+import { GoogleAnalytics } from '@/components/common/google-analytics';
 import { ThemeProvider } from '@/components/common/theme-context';
 import ThemeScript from '@/components/common/theme-script';
 

--- a/apps/blog/src/components/common/google-analytics.tsx
+++ b/apps/blog/src/components/common/google-analytics.tsx
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Google Analytics component for Next.js applications.
+ * @see https://github.com/vercel/next.js/blob/canary/packages/third-parties/src/google/ga.tsx
+ * @see https://nextjs.org/docs/app/api-reference/components/script
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import Script from 'next/script';
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Props used by `GoogleAnalytics` to initialize Google Analytics tracking on a Next.js application.
+ */
+export interface GoogleAnalyticsProps {
+  /**
+   * Google Analytics Measurement ID. (e.g., `'G-XXXXXXXXXX'`)
+   */
+  gaId: string;
+}
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Google Analytics component for Next.js applications.
+ */
+export function GoogleAnalytics({ gaId }: GoogleAnalyticsProps) {
+  return (
+    <>
+      <Script
+        id="_next-ga-init"
+        dangerouslySetInnerHTML={{
+          __html: `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${gaId}');
+`.trim(),
+        }}
+      />
+      <Script id="_next-ga" src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} />
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "@lumir/remark-plugins": "*",
         "@lumir/styles": "*",
         "@lumir/utils": "*",
-        "@next/third-parties": "^16.2.6",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "babel-plugin-react-compiler": "^1.0.0",
@@ -1991,19 +1990,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@next/third-parties": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
-      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "third-party-capital": "1.0.20"
-      },
-      "peerDependencies": {
-        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11406,12 +11392,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/third-party-capital": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
-      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
-      "license": "ISC"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",


### PR DESCRIPTION
This pull request refactors the integration of Google Analytics in the blog application by replacing the dependency on the external `@next/third-parties` package with a custom local implementation. The update improves maintainability and control over the analytics component, while cleaning up related dependencies.

Analytics integration refactor:

* Removed the `@next/third-parties` dependency from `package.json`, eliminating reliance on the external analytics package.
* Replaced the import of `GoogleAnalytics` from `@next/third-parties/google` with a local import from `@/components/common/google-analytics` in `layout.tsx`.
* Added a new `GoogleAnalytics` component in `google-analytics.tsx`, which uses the Next.js `Script` component to initialize Google Analytics with a provided measurement ID.