### PR TITLE
build(blog): migrate blog to static export

### DIFF
--- a/apps/blog/next.config.js
+++ b/apps/blog/next.config.js
@@ -3,13 +3,17 @@
  */
 
 // --------------------------------------------------------------------------------
-// Helpers
+// Helper
 // --------------------------------------------------------------------------------
 
 const isProd = process.env.NODE_ENV === 'production';
 
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {
+export default {
   pageExtensions: ['js', 'mjs', 'jsx', 'ts', 'mts', 'tsx', 'md', 'mdx'],
   images: {
     remotePatterns: [
@@ -31,6 +35,10 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true, // Typecheck will be handled separately.
   },
+  output: 'export',
+  trailingSlash: false,
+  skipTrailingSlashRedirect: true,
+  distDir: 'build',
 
   webpack(config) {
     // Add a rule to handle Markdown files as raw text.
@@ -42,9 +50,3 @@ const nextConfig = {
     return config;
   },
 };
-
-// --------------------------------------------------------------------------------
-// Export
-// --------------------------------------------------------------------------------
-
-export default nextConfig;

--- a/apps/blog/next.config.js
+++ b/apps/blog/next.config.js
@@ -16,6 +16,7 @@ const isProd = process.env.NODE_ENV === 'production';
 export default {
   pageExtensions: ['js', 'mjs', 'jsx', 'ts', 'mts', 'tsx', 'md', 'mdx'],
   images: {
+    unoptimized: true, // For static export, we need to disable image optimization.
     remotePatterns: [
       {
         hostname: 'avatars.githubusercontent.com', // Allow GitHub profile image.
@@ -35,10 +36,10 @@ export default {
   typescript: {
     ignoreBuildErrors: true, // Typecheck will be handled separately.
   },
-  output: 'export',
-  trailingSlash: false,
-  skipTrailingSlashRedirect: true,
-  distDir: 'build',
+  output: 'export', // For static export, we need to set output to 'export'.
+  trailingSlash: false, // For static export, we don't want trailing slashes.
+  skipTrailingSlashRedirect: true, // For static export, we don't want to redirect to trailing slashes.
+  distDir: 'build', // For static export, set the output directory to 'build' to match existing coventions.
 
   webpack(config) {
     // Add a rule to handle Markdown files as raw text.

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -54,6 +54,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/webpack-env": "^1.18.8",
+    "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }
 }

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "next dev --webpack",
     "build": "node --run test:types && next build --webpack",
-    "start": "next start",
+    "start": "vite preview --open --outDir build --port 3001",
     "test": "node --run test:types && node --run test:unit",
     "test:types": "next typegen && tsgo -b tsconfig.app.json",
     "test:unit": "vitest run",

--- a/apps/blog/src/app/categories/sitemap.ts
+++ b/apps/blog/src/app/categories/sitemap.ts
@@ -17,6 +17,16 @@ import createMarkdownCollection from '@/utils/markdown-collection';
 const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
+// Named Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Change the dynamic behavior of a layout or page to fully static or fully dynamic.
+ * @see https://nextjs.org/docs/app/guides/caching-without-cache-components#dynamic
+ */
+export const dynamic = 'force-static';
+
+// --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 

--- a/apps/blog/src/app/posts/sitemap.ts
+++ b/apps/blog/src/app/posts/sitemap.ts
@@ -17,6 +17,16 @@ import createMarkdownCollection from '@/utils/markdown-collection';
 const markdownCollection = createMarkdownCollection();
 
 // --------------------------------------------------------------------------------
+// Named Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Change the dynamic behavior of a layout or page to fully static or fully dynamic.
+ * @see https://nextjs.org/docs/app/guides/caching-without-cache-components#dynamic
+ */
+export const dynamic = 'force-static';
+
+// --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 

--- a/apps/blog/src/app/robots.ts
+++ b/apps/blog/src/app/robots.ts
@@ -10,6 +10,16 @@ import { type MetadataRoute } from 'next';
 import { WEBSITE_URL } from '@/constants';
 
 // --------------------------------------------------------------------------------
+// Named Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Change the dynamic behavior of a layout or page to fully static or fully dynamic.
+ * @see https://nextjs.org/docs/app/guides/caching-without-cache-components#dynamic
+ */
+export const dynamic = 'force-static';
+
+// --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 

--- a/apps/blog/src/app/sitemap.ts
+++ b/apps/blog/src/app/sitemap.ts
@@ -10,6 +10,16 @@ import { type MetadataRoute } from 'next';
 import { WEBSITE_URL } from '@/constants';
 
 // --------------------------------------------------------------------------------
+// Named Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Change the dynamic behavior of a layout or page to fully static or fully dynamic.
+ * @see https://nextjs.org/docs/app/guides/caching-without-cache-components#dynamic
+ */
+export const dynamic = 'force-static';
+
+// --------------------------------------------------------------------------------
 // Default Export
 // --------------------------------------------------------------------------------
 

--- a/apps/blog/tsconfig.app.json
+++ b/apps/blog/tsconfig.app.json
@@ -9,7 +9,7 @@
     "src/**/*.mts",
     "src/**/*.cts",
     "src/**/*.tsx",
-    ".next/types/**/*.ts"
+    "build/types/**/*.ts"
   ],
   "references": [
     {

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,5 +1,7 @@
 {
   "buildCommand": "node --run count-docs && node --run build",
+  "cleanUrls": true,
+  "framework": null,
   "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
   "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ../..",
   "outputDirectory": "build",

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "node --run count-docs && node --run build",
-  "framework": "nextjs",
   "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
   "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ../..",
   "outputDirectory": "build",

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -3,6 +3,6 @@
   "framework": "nextjs",
   "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
   "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ../..",
-  "outputDirectory": ".next",
+  "outputDirectory": "build",
   "regions": ["icn1"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default defineConfig([
       'apps/moing/',
       '**/build/',
       '**/coverage/',
+      '**/.next/',
       '**/archives/',
       '**/next-env.d.ts',
       '**/.tsbuildinfo',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,6 @@ export default defineConfig([
       'apps/moing/',
       '**/build/',
       '**/coverage/',
-      '**/.next/',
       '**/archives/',
       '**/next-env.d.ts',
       '**/.tsbuildinfo',

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@types/webpack-env": "^1.18.8",
+        "vite": "^8.0.16",
         "vitest": "^4.1.8"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "build:pkg:rmp": "npm run build -w packages/remark-plugins",
     "build:pkg:t": "npm run build -w packages/types",
     "build:pkg:u": "npm run build -w packages/utils",
+    "start:b": "npm run start -w apps/blog",
+    "start:m": "npm run start -w apps/moing",
     "start:a:b": "npm run start -w apps/blog",
     "start:a:m": "npm run start -w apps/moing",
     "req": "node ./apps/api/src/dev/client.ts",


### PR DESCRIPTION
This pull request updates the blog app configuration to support static export with Next.js, improves static behavior declarations, and introduces Vite for local previewing. The main changes focus on enabling static export, updating build and start scripts, and ensuring the app's output and type files align with the new build process.

**Static Export & Next.js Configuration:**
- Updated `next.config.js` to use ES module export, set `output: 'export'`, disabled image optimization, removed trailing slashes, and changed the output directory to `build` for static export compatibility. [[1]](diffhunk://#diff-8b8aa807d37450b340406ba7a5e3340ee16ed8a05df0c07b56215c3c5c359809L6-R19) [[2]](diffhunk://#diff-8b8aa807d37450b340406ba7a5e3340ee16ed8a05df0c07b56215c3c5c359809R39-R42) [[3]](diffhunk://#diff-8b8aa807d37450b340406ba7a5e3340ee16ed8a05df0c07b56215c3c5c359809L45-L50)
- Changed the type output directory in `tsconfig.app.json` from `.next/types` to `build/types` to match the new static export output.
- Updated `vercel.json` to set `outputDirectory` to `build`, disable the Next.js framework auto-detection, and enable clean URLs.

**Build and Preview Scripts:**
- Switched the `start` script in `apps/blog/package.json` to use `vite preview` for serving the static build, and added Vite as a dependency. [[1]](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171L11-R11) [[2]](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171R57)

**Static Behavior Declarations:**
- Added `export const dynamic = 'force-static';` to all sitemap and robots files to ensure these routes are treated as fully static by Next.js. [[1]](diffhunk://#diff-4fa80ec2c7821fb4902f5293a2727982485cc0648d44ce5b0b8118d82cec36b9R19-R28) [[2]](diffhunk://#diff-3193e8e060d6f9c062f0e007f89e4e4cb55db65ed93f20f099811febc4d7808dR19-R28) [[3]](diffhunk://#diff-0c24a44b9b074baadc75c00ad04997b28b867a2ffc49e8b6d3ad18adba76473dR12-R21) [[4]](diffhunk://#diff-abd287efec8498ea7ed7d0a7e870501282276f9fb5f764802fb5fa65cf83021aR12-R21)

**Monorepo Script Updates:**
- Added new monorepo scripts for starting the blog and moing apps (`start:b`, `start:m`) for convenience.