### PR TITLE
refactor(moing): update config file ignore patterns and turn on ESLint

### DIFF
--- a/apps/moing/src/contexts/config-context.tsx
+++ b/apps/moing/src/contexts/config-context.tsx
@@ -81,7 +81,7 @@ export type QuestionType = (typeof questionTypes)[number];
  * including the current configuration state and helper functions for updating the config
  * and checking if it's complete.
  */
-export type ConfigContextValue = {
+export interface ConfigContextValue {
   /**
    * Current interview configuration.
    */
@@ -96,7 +96,7 @@ export type ConfigContextValue = {
    * Returns whether the required interview configuration is complete.
    */
   readonly isConfigDone: () => boolean;
-};
+}
 
 // --------------------------------------------------------------------------------
 // Helper

--- a/apps/moing/src/contexts/scenario-context.tsx
+++ b/apps/moing/src/contexts/scenario-context.tsx
@@ -109,7 +109,7 @@ interface Section {
  * Defines the shape of the scenario context value provided by the `ScenarioContext`,
  * including the current section and navigation actions.
  */
-type ScenarioContextValue = {
+interface ScenarioContextValue {
   /**
    * Current section selected by `scenario[chapter][section]`.
    */
@@ -129,7 +129,7 @@ type ScenarioContextValue = {
    * Returns whether the current section is the last section of its chapter.
    */
   readonly isLastSection: () => boolean;
-};
+}
 
 // --------------------------------------------------------------------------------
 // Helper

--- a/apps/moing/src/temp/prompt.ts
+++ b/apps/moing/src/temp/prompt.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { type CustomChatCompletionMessageParam } from './types.js';
-import { type QuestionType } from '../contexts/config-context.js';
+import { type QuestionType } from '@/contexts/config-context';
 
 // --------------------------------------------------------------------------------
 // Export

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,11 +18,10 @@ import md from 'eslint-markdown';
 export default defineConfig([
   globalIgnores(
     [
-      'apps/moing/',
+      '**/archives/',
       '**/build/',
       '**/coverage/',
       '**/.next/',
-      '**/archives/',
       '**/next-env.d.ts',
       '**/.tsbuildinfo',
     ],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,7 +1,13 @@
 /** @type {import('stylelint').Config} */
 export default {
   extends: ['stylelint-config-standard', 'stylelint-config-recess-order'],
-  ignoreFiles: ['apps/moing/**', 'archives/**', 'coverage/**'],
+  ignoreFiles: [
+    'apps/moing/**',
+    '**/archives/**',
+    '**/build/**',
+    '**/coverage/**',
+    '**/.next/**',
+  ],
   rules: {
     'import-notation': 'string',
     // Enforce specific media feature breakpoints for consistency


### PR DESCRIPTION
This pull request refactors some TypeScript context types to use interfaces instead of type aliases, updates import paths for consistency, and improves ignore patterns in linting configurations. These changes help standardize code style, improve maintainability, and ensure proper linting coverage across the project.

**TypeScript context type refactoring:**

* Converted `ConfigContextValue` and `ScenarioContextValue` from type aliases to interfaces for better extensibility and consistency in `config-context.tsx` and `scenario-context.tsx`. [[1]](diffhunk://#diff-9f8d3e2615354e9ea95d4e3bc37b42e9cb7f7d5f196f009bffd13a85b688dab7L84-R84) [[2]](diffhunk://#diff-9f8d3e2615354e9ea95d4e3bc37b42e9cb7f7d5f196f009bffd13a85b688dab7L99-R99) [[3]](diffhunk://#diff-3179ad9f5a7b87ca2e94f3e3e8da199ffc145809a07e63db49ea2a64044b27d4L112-R112) [[4]](diffhunk://#diff-3179ad9f5a7b87ca2e94f3e3e8da199ffc145809a07e63db49ea2a64044b27d4L132-R132)

**Import path improvements:**

* Updated the import path for `QuestionType` in `prompt.ts` to use an absolute alias (`@/contexts/config-context`) instead of a relative path.

**Linting configuration updates:**

* Enhanced ignore patterns in `stylelint.config.js` to consistently exclude archives, build, coverage, and `.next` directories across all subdirectories.
* Updated ignore patterns in `eslint.config.js` to only exclude the `archives` directory and not the entire `apps/moing/` directory, ensuring better linting coverage.