### PR TITLE
refactor(blog): rename search params for category sorting

### DIFF
--- a/apps/blog/src/components/article/post-list.tsx
+++ b/apps/blog/src/components/article/post-list.tsx
@@ -3,7 +3,7 @@
  *
  * NOTE: We use `Suspense` instead of `useEffect` to reduce visual jump.
  * With `useEffect`, the default post list is painted first,
- * and the search-param-based order is applied afterward when the effect runs.
+ * and the search-param-based sort is applied afterward when the effect runs.
  */
 
 // --------------------------------------------------------------------------------
@@ -53,35 +53,35 @@ interface PostListProps {
  */
 interface SortedPostListProps extends PostListProps {
   /**
-   * The order in which the posts should be sorted.
+   * The field by which the posts should be sorted.
    */
-  readonly order: SortKey;
+  readonly field: SortableFrontmatterKey;
 
   /**
-   * The key by which the posts should be sorted.
+   * The sort direction applied to the posts.
    */
-  readonly sort: SortableFrontmatterKey;
+  readonly sort: SortKey;
 }
 
 // --------------------------------------------------------------------------------
 // Helper
 // --------------------------------------------------------------------------------
 
-const DEFAULT_SORT = 'updated' satisfies SortableFrontmatterKey;
-const DEFAULT_ORDER = 'desc' satisfies SortKey;
+const DEFAULT_FIELD = 'updated' satisfies SortableFrontmatterKey;
+const DEFAULT_SORT = 'desc' satisfies SortKey;
 
-function normalizeSort(sort: string | null): SortableFrontmatterKey {
-  return sort === 'title' || sort === 'created' || sort === 'updated'
-    ? sort
-    : DEFAULT_SORT;
+function normalizeField(field: string | null): SortableFrontmatterKey {
+  return field === 'title' || field === 'created' || field === 'updated'
+    ? field
+    : DEFAULT_FIELD;
 }
 
-function normalizeOrder(order: string | null): SortKey {
-  return order === 'asc' || order === 'desc' ? order : DEFAULT_ORDER;
+function normalizeSort(sort: string | null): SortKey {
+  return sort === 'asc' || sort === 'desc' ? sort : DEFAULT_SORT;
 }
 
-function SortedPostList({ items, sort, order }: SortedPostListProps) {
-  const compare = compareMarkdownDocument(sort, order);
+function SortedPostList({ items, field, sort }: SortedPostListProps) {
+  const compare = compareMarkdownDocument(field, sort);
 
   return (
     <div className={styles['post-list']}>
@@ -100,7 +100,7 @@ function SortedPostListSearchParams({ items }: PostListProps) {
   return (
     <SortedPostList
       items={items}
-      order={normalizeOrder(searchParams.get('order'))} // TODO: Rename `sort` and `order`.
+      field={normalizeField(searchParams.get('field'))}
       sort={normalizeSort(searchParams.get('sort'))}
     />
   );
@@ -114,7 +114,7 @@ export default function PostList({ items }: PostListProps) {
   return (
     <Suspense
       fallback={
-        <SortedPostList items={items} order={DEFAULT_ORDER} sort={DEFAULT_SORT} />
+        <SortedPostList items={items} field={DEFAULT_FIELD} sort={DEFAULT_SORT} />
       }
     >
       <SortedPostListSearchParams items={items} />

--- a/apps/blog/src/components/nav/sort.module.css
+++ b/apps/blog/src/components/nav/sort.module.css
@@ -47,7 +47,7 @@
     letter-spacing: var(--size-letter-spacing-medium);
   }
 
-  & > div.order {
+  & > div.sort {
     grid-area: 1 / 3 / 3 / 4;
 
     & > svg {

--- a/apps/blog/src/components/nav/sort.tsx
+++ b/apps/blog/src/components/nav/sort.tsx
@@ -39,7 +39,7 @@ function SortContainer({ children }: PropsWithChildren) {
         </div>
         <div className={styles['name-en']}>Sort</div>
         <div className={styles['name-ko']}>정렬</div>
-        <div className={cn(styles.order, 'custom-flex-center')}>
+        <div className={cn(styles.sort, 'custom-flex-center')}>
           {isOpen ? <FaAngleUp /> : <FaAngleDown />}
         </div>
       </div>
@@ -48,15 +48,15 @@ function SortContainer({ children }: PropsWithChildren) {
   );
 }
 
-function SortItem({ sort, order }: { sort: SortableFrontmatterKey; order: SortKey }) {
+function SortItem({ field, sort }: { field: SortableFrontmatterKey; sort: SortKey }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   function onClick() {
     const params = new URLSearchParams(searchParams.toString());
 
+    params.set('field', field);
     params.set('sort', sort);
-    params.set('order', order);
 
     window.history.replaceState(null, '', `${pathname}?${params.toString()}`);
   }
@@ -64,16 +64,16 @@ function SortItem({ sort, order }: { sort: SortableFrontmatterKey; order: SortKe
   return (
     <li className={cn(styles['sort-item'], 'custom-hover-effect')} onClick={onClick}>
       <div className={cn(styles['react-icons'], 'custom-flex-center')}>
-        {frontmatterMeta[sort].reactIcons}
+        {frontmatterMeta[field].reactIcons}
       </div>
       <div
         className={styles['name-en']}
-      >{`${frontmatterMeta[sort].name.en} / ${sortMeta[order].name.en}`}</div>
+      >{`${frontmatterMeta[field].name.en} / ${sortMeta[sort].name.en}`}</div>
       <div
         className={styles['name-ko']}
-      >{`${frontmatterMeta[sort].name.ko} / ${sortMeta[order].name.ko}`}</div>
-      <div className={cn(styles.order, 'custom-flex-center')}>
-        {sortMeta[order].reactIcons}
+      >{`${frontmatterMeta[field].name.ko} / ${sortMeta[sort].name.ko}`}</div>
+      <div className={cn(styles.sort, 'custom-flex-center')}>
+        {sortMeta[sort].reactIcons}
       </div>
     </li>
   );
@@ -86,12 +86,12 @@ function SortItem({ sort, order }: { sort: SortableFrontmatterKey; order: SortKe
 export default function Sort() {
   return (
     <SortContainer>
-      <SortItem sort="title" order="desc" />
-      <SortItem sort="title" order="asc" />
-      <SortItem sort="created" order="desc" />
-      <SortItem sort="created" order="asc" />
-      <SortItem sort="updated" order="desc" />
-      <SortItem sort="updated" order="asc" />
+      <SortItem field="title" sort="desc" />
+      <SortItem field="title" sort="asc" />
+      <SortItem field="created" sort="desc" />
+      <SortItem field="created" sort="asc" />
+      <SortItem field="updated" sort="desc" />
+      <SortItem field="updated" sort="asc" />
     </SortContainer>
   );
 }

--- a/apps/blog/src/utils/compare.ts
+++ b/apps/blog/src/utils/compare.ts
@@ -16,16 +16,16 @@ import { markdownToTextSync } from './markdown-to-text';
 // --------------------------------------------------------------------------------
 
 /**
- * Returns a comparison function for sorting markdown documents based on the specified sort key and order.
+ * Returns a comparison function for sorting markdown documents based on the specified field and sort direction.
  */
-export function compareMarkdownDocument(sort: SortableFrontmatterKey, order: SortKey) {
-  switch (sort) {
+export function compareMarkdownDocument(field: SortableFrontmatterKey, sort: SortKey) {
+  switch (field) {
     case 'title': {
       return (a: VMarkdownFileMeta, b: VMarkdownFileMeta) => {
         const titleA = markdownToTextSync(a.data.title.toLowerCase()); // Case insensitive.
         const titleB = markdownToTextSync(b.data.title.toLowerCase()); // Case insensitive.
 
-        return order === 'asc'
+        return sort === 'asc'
           ? titleA.localeCompare(titleB, 'ko') // Ascending.
           : titleB.localeCompare(titleA, 'ko'); // Descending.
       };
@@ -33,21 +33,21 @@ export function compareMarkdownDocument(sort: SortableFrontmatterKey, order: Sor
     case 'created':
     case 'updated': {
       return (a: VMarkdownFileMeta, b: VMarkdownFileMeta) => {
-        const dateA = new Date(a.data[sort]);
-        const dateB = new Date(b.data[sort]);
+        const dateA = new Date(a.data[field]);
+        const dateB = new Date(b.data[field]);
 
         // NaN check for invalid dates
         if (Number.isNaN(dateA.getTime()) || Number.isNaN(dateB.getTime())) {
           throw new TypeError('Invalid date format.');
         }
 
-        return order === 'asc'
+        return sort === 'asc'
           ? dateA.getTime() - dateB.getTime() // Ascending.
           : dateB.getTime() - dateA.getTime(); // Descending.
       };
     }
     default: {
-      throw new TypeError('Invalid sort. Use "title", "created", or "updated".');
+      throw new TypeError('Invalid field. Use "title", "created", or "updated".');
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the sorting logic and related naming conventions in the blog's post list and sort components to improve clarity and consistency. The changes primarily rename variables and props from "order" and "sort" to "field" (the attribute to sort by) and "sort" (the direction), update related helper functions, and adjust UI components and styles to match the new terminology.

**Refactoring sorting logic and naming:**

* Renamed props and variables in `SortedPostList` and related helpers from `order`/`sort` to `field` (the field to sort by) and `sort` (the direction), and updated their usage throughout `post-list.tsx`. [[1]](diffhunk://#diff-e2ddaf4fc8249c96a8165f05d89482e6d03c64ff6b2807091a0a1592b51635a4L56-R84) [[2]](diffhunk://#diff-e2ddaf4fc8249c96a8165f05d89482e6d03c64ff6b2807091a0a1592b51635a4L103-R103) [[3]](diffhunk://#diff-e2ddaf4fc8249c96a8165f05d89482e6d03c64ff6b2807091a0a1592b51635a4L117-R117)
* Updated the `compareMarkdownDocument` function signature and implementation to use `field` and `sort` instead of `sort` and `order`, and clarified related error messages.

**UI and style updates:**

* Changed CSS classes and JSX references from `.order` to `.sort` in `sort.module.css` and `sort.tsx` to match the new terminology. [[1]](diffhunk://#diff-7ed938d067722c716d1e63de23239b911e555d59400b44c00666a8698640971cL50-R50) [[2]](diffhunk://#diff-8c533d0178d1c13ac3478a342d455d2341afc82349603257ecd84aa9b2cd430fL42-R42)
* Updated the `SortItem` component to use `field` and `sort` props, adjusted URL parameter logic, and revised label rendering for clarity.
* Modified the `Sort` component to pass the new `field` and `sort` props to `SortItem` instances.

**Documentation and comment improvements:**

* Updated comments and docstrings to reflect the new sorting terminology, improving code readability. [[1]](diffhunk://#diff-e2ddaf4fc8249c96a8165f05d89482e6d03c64ff6b2807091a0a1592b51635a4L6-R6) [[2]](diffhunk://#diff-8c399083e87134cbc7af9993e79afe4647d8cf49f8a265bc1abc40518b319cc0L19-R50)