### PR TITLE
feat(@lumir/styles): share common animation keyframes

### DIFF
--- a/apps/blog/src/styles/animations.css
+++ b/apps/blog/src/styles/animations.css
@@ -26,16 +26,3 @@
     transform: rotate(0deg) translateX(0);
   }
 }
-
-/**
- * Animation for fading in an element.
- */
-@keyframes animation-fade-in {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}

--- a/apps/blog/src/styles/index.css
+++ b/apps/blog/src/styles/index.css
@@ -1,5 +1,6 @@
 /* External */
 @import '@lumir/styles/normalize.css';
+@import '@lumir/styles/animations.css';
 @import 'katex/dist/katex.min.css';
 
 /* Internal */

--- a/apps/blog/src/styles/variables.css
+++ b/apps/blog/src/styles/variables.css
@@ -36,7 +36,7 @@
 
   /* list */
   --animation-shake: animation-shake 0.6s ease-in-out;
-  --animation-fade-in: animation-fade-in 0.6s ease-in-out;
+  --animation-fade-in: fade-in 0.6s ease-in-out;
   --border-default: 1px solid var(--color-border-default);
 
   /* font */

--- a/apps/moing/src/components/main-button.module.css
+++ b/apps/moing/src/components/main-button.module.css
@@ -1,21 +1,10 @@
 .main-button {
-  animation: 8s ease-in-out;
-  animation-name: loadEffect1, loadEffect2;
+  animation: /* NOTE: `global()` is CSS Modules specific syntax */
+    4s ease-in-out 4s backwards global(fade-in),
+    8s ease-in-out pointer-events-none;
 }
 
-@keyframes loadEffect1 {
-  0% {
-    opacity: 0;
-  }
-  50% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes loadEffect2 {
+@keyframes pointer-events-none {
   from {
     pointer-events: none;
   }

--- a/apps/moing/src/components/server.module.css
+++ b/apps/moing/src/components/server.module.css
@@ -11,12 +11,6 @@
   }
 
   & .cursor {
-    animation: blink 1s steps(1, end) infinite;
-  }
-}
-
-@keyframes blink {
-  50% {
-    opacity: 0;
+    animation: global(blink) 1s steps(1, end) infinite; /* NOTE: `global()` is CSS Modules specific syntax */
   }
 }

--- a/apps/moing/src/components/title.module.css
+++ b/apps/moing/src/components/title.module.css
@@ -19,7 +19,7 @@
     /* others */
     transform: rotate(-10deg);
     /* loading effects */
-    animation: 2s ease-in-out loadEffect3;
+    animation: 2s ease-in-out global(fade-in); /* NOTE: `global()` is CSS Modules specific syntax */
   }
   & > .interview {
     /* box */
@@ -27,27 +27,6 @@
     /* text */
     text-align: center;
     /* loading effects */
-    animation: 4s ease-in-out loadEffect4;
-  }
-}
-
-@keyframes loadEffect3 {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes loadEffect4 {
-  0% {
-    opacity: 0;
-  }
-  50% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
+    animation: 2s ease-in-out 2s backwards global(fade-in); /* NOTE: `global()` is CSS Modules specific syntax */
   }
 }

--- a/apps/moing/src/styles/index.css
+++ b/apps/moing/src/styles/index.css
@@ -1,5 +1,6 @@
 /* External */
 @import '@lumir/styles/normalize.css';
+@import '@lumir/styles/animations.css';
 
 /* Internal */
 @import './typography.css';

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0-private",
   "type": "module",
   "exports": {
+    "./animations.css": "./src/animations.css",
     "./normalize.css": "./src/normalize.css",
     "./package.json": "./package.json"
   }

--- a/packages/styles/src/animations.css
+++ b/packages/styles/src/animations.css
@@ -1,0 +1,34 @@
+/**
+ * Animation for blinking an element.
+ */
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/**
+ * Animation for fading in an element.
+ */
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+/**
+ * Animation for fading out an element.
+ */
+@keyframes fade-out {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
This pull request centralizes and standardizes animation keyframes by moving them into a shared `@lumir/styles/animations.css` file, updates animation usage across multiple apps to reference these shared animations, and ensures proper export and import of the new animation styles. It also updates the animation syntax for compatibility with CSS Modules and removes redundant, app-local animation definitions.

**Shared animation keyframes and usage standardization:**

* Added `blink`, `fade-in`, and `fade-out` keyframes to `packages/styles/src/animations.css`, making them available for all apps to use.
* Updated `packages/styles/package.json` to export the new `animations.css` file, enabling its use as a shared package resource.
* Removed local animation keyframe definitions from `apps/blog/src/styles/animations.css` and replaced usage with references to the shared `fade-in` animation.
* Updated animation variable in `apps/blog/src/styles/variables.css` to use the shared `fade-in` keyframe.

**App-level animation usage refactoring:**

* Updated imports in `apps/blog/src/styles/index.css` and `apps/moing/src/styles/index.css` to include the shared `@lumir/styles/animations.css` file. [[1]](diffhunk://#diff-6960b1a8a9e41809a5b71616ba46c1fd3deba56bc13db75bd349537af041ce62R3) [[2]](diffhunk://#diff-1921dcc0885a522dcb170dae86213c8e1513f4786e5db696d25720dc75876498R3)
* Refactored animation usage in `apps/moing/src/components/main-button.module.css`, `server.module.css`, and `title.module.css` to use `global(fade-in)` and `global(blink)` for compatibility with CSS Modules, and removed redundant local keyframes. [[1]](diffhunk://#diff-7c6609bd9f958b3dfef59a8eae680f82641d0c49d7f1c4f25a5b52c59293b4ceL2-R7) [[2]](diffhunk://#diff-528ce7748c5db09ad985a5d7031e60bd1c20d239b69fb5e2744de4871f1fcfbcL14-R14) [[3]](diffhunk://#diff-2ef64058b4f6a523e16500a4280b550edc38fa43abc4d8f68ffcfcd660649204L22-R30)