### PR TITLE
build(blog): separate typegen output from static build

### DIFF
--- a/apps/blog/next.config.js
+++ b/apps/blog/next.config.js
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------------
 
 const isProd = process.env.NODE_ENV === 'production';
+const isTypegen = process.argv.includes('typegen');
 
 // --------------------------------------------------------------------------------
 // Export
@@ -39,7 +40,7 @@ export default {
   output: 'export', // For static export, we need to set output to 'export'.
   trailingSlash: false, // For static export, we don't want trailing slashes.
   skipTrailingSlashRedirect: true, // For static export, we don't want to redirect to trailing slashes.
-  distDir: 'build', // For static export, set the output directory to 'build' to match existing coventions.
+  distDir: isTypegen ? '.next' : 'build', // For static export, use a separate dist directory to prevent type generation conflicts.
 
   webpack(config) {
     // Add a rule to handle Markdown files as raw text.

--- a/apps/blog/tsconfig.app.json
+++ b/apps/blog/tsconfig.app.json
@@ -9,7 +9,7 @@
     "src/**/*.mts",
     "src/**/*.cts",
     "src/**/*.tsx",
-    "build/types/**/*.ts"
+    ".next/types/**/*.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
This pull request updates the build and type generation configuration for the blog app to avoid conflicts between static export output and type generation. The main focus is on ensuring that the type generation process uses a separate output directory, which prevents issues when running builds and generating types concurrently.

Build and type generation configuration:

* Added an `isTypegen` flag in `next.config.js` to detect when type generation is running, based on process arguments.
* Updated the `distDir` in `next.config.js` to use `.next` as the output directory during type generation, and `build` otherwise, preventing conflicts between build output and generated types.
* Changed the `tsconfig.app.json` to reference `.next/types/**/*.ts` instead of `build/types/**/*.ts`, aligning type references with the new output directory used during type generation.