### PR TITLE
test(@lumir/rehype-plugins): add type tests for `rehype-plugins`

### DIFF
--- a/packages/rehype-plugins/src/rehype-image-lazy-loading.test-d.ts
+++ b/packages/rehype-plugins/src/rehype-image-lazy-loading.test-d.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Type test for `rehype-image-lazy-loading.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { rehypeImageLazyLoading } from './rehype-image-lazy-loading.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region rehypeImageLazyLoading
+
+({}) as typeof rehypeImageLazyLoading satisfies Function;
+({}) as ReturnType<typeof rehypeImageLazyLoading> satisfies Function;
+
+// @ts-expect-error - `rehypeImageLazyLoading` should not accept options.
+rehypeImageLazyLoading({});
+// @ts-expect-error - `rehypeImageLazyLoading` should be a function.
+({}) as typeof rehypeImageLazyLoading satisfies boolean;
+// @ts-expect-error - `rehypeImageLazyLoading` should be a function.
+({}) as typeof rehypeImageLazyLoading satisfies string;
+
+// #endregion rehypeImageLazyLoading
+// --------------------------------------------------------------------------------

--- a/packages/rehype-plugins/src/rehype-image-url-replace.test-d.ts
+++ b/packages/rehype-plugins/src/rehype-image-url-replace.test-d.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Type test for `rehype-image-url-replace.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import {
+  rehypeImageUrlReplace,
+  type RehypeImageUrlReplaceOptions,
+} from './rehype-image-url-replace.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region RehypeImageUrlReplaceOptions
+
+let options: RehypeImageUrlReplaceOptions;
+
+options = { searchValue: /^\/public/, replaceValue: '' };
+
+// @ts-expect-error - `searchValue` should be a RegExp.
+options = { searchValue: '^/public', replaceValue: '' };
+// @ts-expect-error - `replaceValue` should be a string.
+options = { searchValue: /^\/public/, replaceValue: 123 };
+// @ts-expect-error - `searchValue` is required.
+options = { replaceValue: '' };
+// @ts-expect-error - `replaceValue` is required.
+options = { searchValue: /^\/public/ };
+// @ts-expect-error - `unknown` is not a valid property of `RehypeImageUrlReplaceOptions`.
+options = { searchValue: /^\/public/, replaceValue: '', unknown: 'unknown' };
+
+// #endregion RehypeImageUrlReplaceOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region rehypeImageUrlReplace
+
+({}) as typeof rehypeImageUrlReplace satisfies Function;
+({}) as Parameters<
+  typeof rehypeImageUrlReplace
+>[0] satisfies RehypeImageUrlReplaceOptions;
+({}) as ReturnType<typeof rehypeImageUrlReplace> satisfies Function;
+
+// @ts-expect-error - `rehypeImageUrlReplace` requires options.
+rehypeImageUrlReplace();
+// @ts-expect-error - `rehypeImageUrlReplace` should be a function.
+({}) as typeof rehypeImageUrlReplace satisfies boolean;
+// @ts-expect-error - `rehypeImageUrlReplace` should be a function.
+({}) as typeof rehypeImageUrlReplace satisfies string;
+
+// #endregion rehypeImageUrlReplace
+// --------------------------------------------------------------------------------

--- a/packages/rehype-plugins/src/rehype-image-url-replace.ts
+++ b/packages/rehype-plugins/src/rehype-image-url-replace.ts
@@ -13,8 +13,19 @@ import type { Root } from 'hast';
 // Typedef
 // --------------------------------------------------------------------------------
 
+/**
+ * Options for the `rehypeImageUrlReplace` plugin.
+ */
 export interface RehypeImageUrlReplaceOptions {
+  /**
+   * A regular expression to search for in image URLs.
+   * The `y` flag will be ignored if present.
+   */
   searchValue: RegExp;
+
+  /**
+   * A string to replace the matched portion of the image URL.
+   */
   replaceValue: string;
 }
 


### PR DESCRIPTION
This pull request introduces type tests for two rehype plugins and improves the type definitions for `rehypeImageUrlReplace`. The main focus is on ensuring type safety and proper usage of the plugin APIs, as well as enhancing documentation for the options interface.

### Type Tests and Type Safety

* Added a new type test file `rehype-image-lazy-loading.test-d.ts` to verify that `rehypeImageLazyLoading` is correctly typed as a function and does not accept options.
* Added a new type test file `rehype-image-url-replace.test-d.ts` to check that `rehypeImageUrlReplace` enforces correct option types and API usage, including required properties and property types for `RehypeImageUrlReplaceOptions`.

### Type Definition Improvements

* Enhanced the `RehypeImageUrlReplaceOptions` interface in `rehype-image-url-replace.ts` with more detailed documentation for each property, specifying the expected types and behavior.