### PR TITLE
chore(*): add package files manifests

### DIFF
--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -32,6 +32,13 @@
       ]
     }
   },
+  "files": [
+    "src",
+    "build",
+    "!src/**/*.test.{js,jsx,ts,tsx}",
+    "!src/**/*.test-d.ts",
+    "!**/fixtures/**"
+  ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json",
     "dev": "tsgo -b tsconfig.build.json --watch",

--- a/packages/react-kit/package.json
+++ b/packages/react-kit/package.json
@@ -33,10 +33,11 @@
     }
   },
   "files": [
-    "src",
     "build",
-    "!src/**/*.test.{js,jsx,ts,tsx}",
-    "!src/**/*.test-d.ts",
+    "LICENSE.md",
+    "README.md",
+    "!src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}",
+    "!src/**/*.test-d.{ts,mts,cts,tsx}",
     "!**/fixtures/**"
   ],
   "scripts": {

--- a/packages/rehype-plugins/package.json
+++ b/packages/rehype-plugins/package.json
@@ -19,10 +19,11 @@
     }
   },
   "files": [
-    "src",
     "build",
-    "!src/**/*.test.{js,jsx,ts,tsx}",
-    "!src/**/*.test-d.ts",
+    "LICENSE.md",
+    "README.md",
+    "!src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}",
+    "!src/**/*.test-d.{ts,mts,cts,tsx}",
     "!**/fixtures/**"
   ],
   "scripts": {

--- a/packages/rehype-plugins/package.json
+++ b/packages/rehype-plugins/package.json
@@ -18,6 +18,13 @@
       ]
     }
   },
+  "files": [
+    "src",
+    "build",
+    "!src/**/*.test.{js,jsx,ts,tsx}",
+    "!src/**/*.test-d.ts",
+    "!**/fixtures/**"
+  ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json",
     "dev": "tsgo -b tsconfig.build.json --watch",

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -19,10 +19,11 @@
     }
   },
   "files": [
-    "src",
     "build",
-    "!src/**/*.test.{js,jsx,ts,tsx}",
-    "!src/**/*.test-d.ts",
+    "LICENSE.md",
+    "README.md",
+    "!src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}",
+    "!src/**/*.test-d.{ts,mts,cts,tsx}",
     "!**/fixtures/**"
   ],
   "scripts": {

--- a/packages/remark-plugins/package.json
+++ b/packages/remark-plugins/package.json
@@ -18,6 +18,13 @@
       ]
     }
   },
+  "files": [
+    "src",
+    "build",
+    "!src/**/*.test.{js,jsx,ts,tsx}",
+    "!src/**/*.test-d.ts",
+    "!**/fixtures/**"
+  ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json",
     "dev": "tsgo -b tsconfig.build.json --watch",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -7,5 +7,9 @@
     "./animations.css": "./src/animations.css",
     "./normalize.css": "./src/normalize.css",
     "./package.json": "./package.json"
-  }
+  },
+  "files": [
+    "src",
+    "!**/fixtures/**"
+  ]
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "src",
-    "!**/fixtures/**"
+    "LICENSE.md",
+    "README.md"
   ]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "src",
-    "!**/fixtures/**"
+    "LICENSE.md",
+    "README.md"
   ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,6 +16,10 @@
       ]
     }
   },
+  "files": [
+    "src",
+    "!**/fixtures/**"
+  ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json"
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,10 +19,11 @@
     }
   },
   "files": [
-    "src",
     "build",
-    "!src/**/*.test.{js,jsx,ts,tsx}",
-    "!src/**/*.test-d.ts",
+    "LICENSE.md",
+    "README.md",
+    "!src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}",
+    "!src/**/*.test-d.{ts,mts,cts,tsx}",
     "!**/fixtures/**"
   ],
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,6 +18,13 @@
       ]
     }
   },
+  "files": [
+    "src",
+    "build",
+    "!src/**/*.test.{js,jsx,ts,tsx}",
+    "!src/**/*.test-d.ts",
+    "!**/fixtures/**"
+  ],
   "scripts": {
     "build": "tsgo -b tsconfig.build.json",
     "dev": "tsgo -b tsconfig.build.json --watch",


### PR DESCRIPTION
This pull request standardizes the published file lists in the `package.json` files across several packages. The main improvement is the addition of the `files` field to control which files are included when each package is published, ensuring only the necessary files are distributed and test/fixture files are excluded.

File inclusion/exclusion for published packages:

* Added a `files` field to `package.json` in `react-kit`, `rehype-plugins`, `remark-plugins`, and `utils` to include build outputs and important documentation, while explicitly excluding test files and fixtures. [[1]](diffhunk://#diff-c9d93c557e255ebd8eea63661f6200a9c05a3abdc4820f6074e7e53ba61a760fR35-R42) [[2]](diffhunk://#diff-f01544832f113658f9724ce7873615af2f7a80667b6ef01ca18845a057ee33c8R21-R28) [[3]](diffhunk://#diff-e9a0588481e249aa226c5ae4f39f9d204991d7516d73961ddc1966dd066527d7R21-R28) [[4]](diffhunk://#diff-21f8eb1d7a149d42ab0454ea905d44f624ff1d0aeb6d7a88d75b42962ca6b053R21-R28)
* Added a `files` field to `package.json` in `styles` and `types` to include the `src` directory and documentation files for publishing. [[1]](diffhunk://#diff-1b9c4fc3d51e8aff3ccf57346453ff963f824fb8e61a2c6fb32dc969377b6019L10-R15) [[2]](diffhunk://#diff-d20e06952213067104fa5b4a1976cbc97cd55806ac11d137d92c905d63c15054R19-R23)