### PR TITLE
feat(@lumir/react-kit)!: require typewriter text argument

### DIFF
--- a/packages/react-kit/src/components/typewriter.test-d.tsx
+++ b/packages/react-kit/src/components/typewriter.test-d.tsx
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Type test for `typewriter.tsx`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { type ComponentProps, type ReactElement } from 'react';
+import { Typewriter, type TypewriterProps } from './typewriter.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region TypewriterProps
+
+let props: TypewriterProps;
+
+props = { text: 'Hello' };
+props = { text: 'Hello', cursor: '|' };
+props = { text: 'Hello', cursor: null };
+props = { text: 'Hello', cursorClassName: 'cursor' };
+props = { text: 'Hello', mode: 'write' };
+props = { text: 'Hello', mode: 'erase' };
+props = { text: 'Hello', writeSpeed: 50 };
+props = { text: 'Hello', eraseSpeed: 50 };
+props = { text: 'Hello', writePreDelay: 0 };
+props = { text: 'Hello', erasePreDelay: 0 };
+props = { text: 'Hello', writePostDelay: 1_500 };
+props = { text: 'Hello', erasePostDelay: 1_500 };
+props = { text: 'Hello', loop: false };
+props = { text: 'Hello', pause: false };
+props = { text: 'Hello', onWriteComplete: () => {} };
+props = { text: 'Hello', onEraseComplete: () => {} };
+props = {
+  text: 'Hello',
+  className: 'typewriter',
+  'aria-label': 'typewriter text',
+  style: { whiteSpace: 'pre' },
+};
+
+// @ts-expect-error - `text` is required.
+props = {};
+// @ts-expect-error - `text` should be a string.
+props = { text: 123 };
+// @ts-expect-error - `cursor` should be a string, null, or undefined.
+props = { text: 'Hello', cursor: false };
+// @ts-expect-error - `cursorClassName` should be a string.
+props = { text: 'Hello', cursorClassName: 123 };
+// @ts-expect-error - `mode` should be `'write'` or `'erase'`.
+props = { text: 'Hello', mode: 'idle' };
+// @ts-expect-error - `writeSpeed` should be a number.
+props = { text: 'Hello', writeSpeed: '50' };
+// @ts-expect-error - `href` is not a valid span attribute.
+props = { text: 'Hello', href: 'https://example.com' };
+// @ts-expect-error - `unknown` is not a valid property of `TypewriterProps`.
+props = { text: 'Hello', unknown: 'unknown' };
+
+// #endregion TypewriterProps
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region Typewriter
+
+({}) as typeof Typewriter satisfies Function;
+({}) as Parameters<typeof Typewriter>[0] satisfies TypewriterProps;
+({}) as ComponentProps<typeof Typewriter> satisfies TypewriterProps;
+({}) as ReturnType<typeof Typewriter> satisfies ReactElement;
+
+// @ts-expect-error - `Typewriter` should be a function.
+({}) as typeof Typewriter satisfies boolean;
+// @ts-expect-error - `Typewriter` should be a function.
+({}) as typeof Typewriter satisfies string;
+
+function TypewriterTypeTest() {
+  return [
+    <Typewriter key="default" text="Hello" />,
+    <Typewriter key="cursor" text="Hello" cursor={null} cursorClassName="cursor" />,
+    <Typewriter key="options" text="Hello" mode="erase" loop pause />,
+    <Typewriter key="span-attributes" text="Hello" aria-label="typewriter text" />,
+
+    // @ts-expect-error - `text` is required.
+    <Typewriter key="missing-text" />,
+    // @ts-expect-error - `text` should be a string.
+    <Typewriter key="invalid-text" text={123} />,
+    // @ts-expect-error - `text` should not be duplicated through an option object.
+    <Typewriter key="invalid-option" text="Hello" options={{ text: 'Hello' }} />,
+  ];
+}
+
+// #endregion Typewriter
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/components/typewriter.tsx
+++ b/packages/react-kit/src/components/typewriter.tsx
@@ -29,6 +29,11 @@ export interface TypewriterProps
    * @default 'cursor'
    */
   cursorClassName?: string;
+
+  /**
+   * Text to type out.
+   */
+  text: string;
 }
 
 // --------------------------------------------------------------------------------
@@ -85,8 +90,7 @@ export function Typewriter({
   // `HTMLAttributes<HTMLSpanElement>`
   ...props
 }: TypewriterProps) {
-  const [currentText] = useTypewriter({
-    text,
+  const [currentText] = useTypewriter(text, {
     mode,
     writeSpeed,
     eraseSpeed,

--- a/packages/react-kit/src/hooks/use-typewriter.test-d.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.test-d.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Type test for `use-typewriter.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useTypewriter, type UseTypewriterOptions } from './use-typewriter.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region UseTypewriterOptions
+
+let options: UseTypewriterOptions;
+
+options = {};
+options = { mode: 'write' };
+options = { mode: 'erase' };
+options = { writeSpeed: 50 };
+options = { eraseSpeed: 50 };
+options = { writePreDelay: 0 };
+options = { erasePreDelay: 0 };
+options = { writePostDelay: 1_500 };
+options = { erasePostDelay: 1_500 };
+options = { loop: false };
+options = { pause: false };
+options = { onWriteComplete: () => {} };
+options = { onEraseComplete: () => {} };
+
+// @ts-expect-error - `text` is passed as the first argument, not as an option.
+options = { text: 'Hello' };
+// @ts-expect-error - `mode` should be `'write'` or `'erase'`.
+options = { mode: 'idle' };
+// @ts-expect-error - `writeSpeed` should be a number.
+options = { writeSpeed: '50' };
+// @ts-expect-error - `loop` should be a boolean.
+options = { loop: 'false' };
+// @ts-expect-error - `onWriteComplete` should be a function.
+options = { onWriteComplete: true };
+// @ts-expect-error - `unknown` is not a valid property of `UseTypewriterOptions`.
+options = { unknown: 'unknown' };
+
+// #endregion UseTypewriterOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useTypewriter
+
+({}) as typeof useTypewriter satisfies Function;
+({}) as Parameters<typeof useTypewriter>[0] satisfies string;
+({}) as Parameters<typeof useTypewriter>[1] satisfies UseTypewriterOptions | undefined;
+({}) as ReturnType<typeof useTypewriter> satisfies readonly [string];
+
+// @ts-expect-error - `useTypewriter` should be a function.
+({}) as typeof useTypewriter satisfies boolean;
+// @ts-expect-error - `useTypewriter` should be a function.
+({}) as typeof useTypewriter satisfies string;
+
+function useTypewriterTypeTest() {
+  useTypewriter('Hello');
+  useTypewriter('Hello', undefined);
+  useTypewriter('Hello', {});
+  useTypewriter('Hello', { mode: 'write' });
+  useTypewriter('Hello', { mode: 'erase' });
+
+  // @ts-expect-error - `useTypewriter` requires text.
+  useTypewriter();
+  // @ts-expect-error - `text` should be a string.
+  useTypewriter(123);
+  // @ts-expect-error - `text` should be passed as the first argument.
+  useTypewriter({ text: 'Hello' });
+  // @ts-expect-error - `text` should not be included in options.
+  useTypewriter('Hello', { text: 'Hello' });
+}
+
+// #endregion useTypewriter
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-typewriter.test.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.test.ts
@@ -32,10 +32,16 @@ describe('use-typewriter', () => {
     });
   });
 
+  it('Default options should start writing from empty text', async () => {
+    const { result } = await renderHook(() => useTypewriter('Hello'));
+
+    const [currentText] = result.current;
+
+    assert.strictEqual(currentText, '');
+  });
+
   it("`mode`: when `mode` is set to `'write'`, initial return value should contain empty text", async () => {
-    const { result } = await renderHook(() =>
-      useTypewriter({ text: 'Hello', mode: 'write' }),
-    );
+    const { result } = await renderHook(() => useTypewriter('Hello', { mode: 'write' }));
 
     const [currentText] = result.current;
 
@@ -43,9 +49,7 @@ describe('use-typewriter', () => {
   });
 
   it("`mode`: when `mode` is set to `'erase'`, initial return value should contain full text", async () => {
-    const { result } = await renderHook(() =>
-      useTypewriter({ text: 'Hello', mode: 'erase' }),
-    );
+    const { result } = await renderHook(() => useTypewriter('Hello', { mode: 'erase' }));
 
     const [currentText] = result.current;
 
@@ -54,8 +58,7 @@ describe('use-typewriter', () => {
 
   it('`writeSpeed`: should respect `writeSpeed` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'Hello',
+      useTypewriter('Hello', {
         mode: 'write',
         writeSpeed: RAF_FRAME_DURATION_MS,
       }),
@@ -128,8 +131,7 @@ describe('use-typewriter', () => {
 
   it('`eraseSpeed`: should respect `eraseSpeed` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'Hello',
+      useTypewriter('Hello', {
         mode: 'erase',
         eraseSpeed: RAF_FRAME_DURATION_MS,
       }),
@@ -202,8 +204,7 @@ describe('use-typewriter', () => {
 
   it('`writePreDelay`: should respect `writePreDelay` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'Hello',
+      useTypewriter('Hello', {
         mode: 'write',
         writePreDelay: RAF_FRAME_DURATION_MS * 2, // 2 frames delay before writing starts
       }),
@@ -235,8 +236,7 @@ describe('use-typewriter', () => {
 
   it('`erasePreDelay`: should respect `erasePreDelay` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'Hello',
+      useTypewriter('Hello', {
         mode: 'erase',
         erasePreDelay: RAF_FRAME_DURATION_MS * 2, // 2 frames delay before erasing starts
       }),
@@ -268,8 +268,7 @@ describe('use-typewriter', () => {
 
   it('`writePostDelay`: should respect `writePostDelay` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'A',
+      useTypewriter('A', {
         mode: 'write',
         writePreDelay: RAF_FRAME_DURATION_MS,
         erasePreDelay: RAF_FRAME_DURATION_MS,
@@ -320,8 +319,7 @@ describe('use-typewriter', () => {
 
   it('`erasePostDelay`: should respect `erasePostDelay` option', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'A',
+      useTypewriter('A', {
         mode: 'erase',
         writePreDelay: RAF_FRAME_DURATION_MS,
         erasePreDelay: RAF_FRAME_DURATION_MS,
@@ -372,8 +370,7 @@ describe('use-typewriter', () => {
 
   it('`loop`: should write, erase, and write again when `loop` is enabled', async () => {
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'AB',
+      useTypewriter('AB', {
         mode: 'write',
         writeSpeed: RAF_FRAME_DURATION_MS,
         eraseSpeed: RAF_FRAME_DURATION_MS,
@@ -451,8 +448,7 @@ describe('use-typewriter', () => {
   it('`pause`: should pause and resume writing when `pause` changes', async () => {
     const { act, rerender, result } = await renderHook(
       (props?: { pause: boolean }) =>
-        useTypewriter({
-          text: 'AB',
+        useTypewriter('AB', {
           mode: 'write',
           writeSpeed: RAF_FRAME_DURATION_MS,
           writePreDelay: RAF_FRAME_DURATION_MS,
@@ -500,8 +496,7 @@ describe('use-typewriter', () => {
     const onWriteComplete = vi.fn();
 
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'AB',
+      useTypewriter('AB', {
         mode: 'write',
         writeSpeed: RAF_FRAME_DURATION_MS,
         writePreDelay: RAF_FRAME_DURATION_MS,
@@ -554,8 +549,7 @@ describe('use-typewriter', () => {
 
     const { act, rerender, result } = await renderHook(
       (props?: { onWriteComplete: () => void }) =>
-        useTypewriter({
-          text: 'A',
+        useTypewriter('A', {
           mode: 'write',
           writeSpeed: RAF_FRAME_DURATION_MS,
           writePreDelay: RAF_FRAME_DURATION_MS,
@@ -610,8 +604,7 @@ describe('use-typewriter', () => {
     const onEraseComplete = vi.fn();
 
     const { act, result } = await renderHook(() =>
-      useTypewriter({
-        text: 'AB',
+      useTypewriter('AB', {
         mode: 'erase',
         eraseSpeed: RAF_FRAME_DURATION_MS,
         erasePreDelay: RAF_FRAME_DURATION_MS,
@@ -664,8 +657,7 @@ describe('use-typewriter', () => {
 
     const { act, rerender, result } = await renderHook(
       (props?: { onEraseComplete: () => void }) =>
-        useTypewriter({
-          text: 'A',
+        useTypewriter('A', {
           mode: 'erase',
           eraseSpeed: RAF_FRAME_DURATION_MS,
           erasePreDelay: RAF_FRAME_DURATION_MS,

--- a/packages/react-kit/src/hooks/use-typewriter.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.ts
@@ -22,11 +22,6 @@ type Mode = 'write' | 'erase';
  */
 export interface UseTypewriterOptions {
   /**
-   * Text to type out.
-   */
-  text: string;
-
-  /**
    * The mode of the typewriter effect.
    * - If set to `'write'`, the hook will write the text.
    * - If set to `'erase'`, the hook will erase the text.
@@ -102,14 +97,17 @@ export interface UseTypewriterOptions {
 /**
  * Simple Typewriter Effect hook.
  *
+ * @param text Text to type out.
+ * @param options Options for the typewriter effect.
+ * @returns A readonly tuple containing the current text.
+ *
  * @example
  * ```tsx
  * import { useTypewriter, type UseTypewriterOptions } from '@lumir/react-kit/hooks';
  *
  * function Component() {
- *   const [currentText] = useTypewriter({
+ *   const [currentText] = useTypewriter('Hello, World!', {
  *     // Default Options
- *     text: 'Hello, World!',
  *     mode: 'write',
  *     writeSpeed: 50,
  *     eraseSpeed: 50,
@@ -127,20 +125,22 @@ export interface UseTypewriterOptions {
  * }
  * ```
  */
-export function useTypewriter({
-  text,
-  mode = 'write',
-  writeSpeed = 50,
-  eraseSpeed = 50,
-  writePreDelay = 0,
-  erasePreDelay = 0,
-  writePostDelay = 1_500,
-  erasePostDelay = 1_500,
-  loop = false,
-  pause = false,
-  onWriteComplete: onWriteCompleteProp = undefined,
-  onEraseComplete: onEraseCompleteProp = undefined,
-}: UseTypewriterOptions): readonly [currentText: string] {
+export function useTypewriter(
+  text: string,
+  {
+    mode = 'write',
+    writeSpeed = 50,
+    eraseSpeed = 50,
+    writePreDelay = 0,
+    erasePreDelay = 0,
+    writePostDelay = 1_500,
+    erasePostDelay = 1_500,
+    loop = false,
+    pause = false,
+    onWriteComplete: onWriteCompleteProp = undefined,
+    onEraseComplete: onEraseCompleteProp = undefined,
+  }: UseTypewriterOptions = {},
+): readonly [currentText: string] {
   const [currentText, setCurrentText] = useState<string>(mode === 'write' ? '' : text);
   const [currentMode, setCurrentMode] = useState<Mode>(mode);
 


### PR DESCRIPTION
This pull request refactors the `useTypewriter` hook and the `Typewriter` component to simplify their APIs by requiring the `text` parameter as a separate argument, rather than as part of an options object. It also updates all related type definitions, tests, and documentation to match the new API. Additionally, new type tests are added for both the hook and the component to ensure type safety.

**API Refactoring and Simplification:**

* The `useTypewriter` hook now takes `text` as the first argument and an options object as the second argument, instead of a single options object containing `text`. The `UseTypewriterOptions` interface no longer includes a `text` property. All usage, documentation, and tests have been updated to reflect this change. [[1]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L24-L28) [[2]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508R100-L112) [[3]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L130-R130) [[4]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L143-R143) [[5]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924R35-R52) [[6]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L57-R61) [[7]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L131-R134) [[8]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L205-R207) [[9]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L238-R239) [[10]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L271-R271) [[11]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L323-R322) [[12]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L375-R373) [[13]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L454-R451) [[14]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L503-R499) [[15]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L557-R552) [[16]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L613-R607) [[17]](diffhunk://#diff-b9a6b8dc50681386a081746e807e7ead84800c012625944e699b1bac5093e924L667-R660)
* The `Typewriter` component now passes `text` as a positional argument to `useTypewriter` instead of including it in the options object. The `TypewriterProps` interface explicitly includes a required `text: string` property. [[1]](diffhunk://#diff-95c4056ff6adbcce955b5cbde5f4f178642c7b33c9c5f3a3a28bc027f0a38d59R32-R36) [[2]](diffhunk://#diff-95c4056ff6adbcce955b5cbde5f4f178642c7b33c9c5f3a3a28bc027f0a38d59L88-R93)

**Type Safety Improvements:**

* Added comprehensive type tests for both `useTypewriter` and `Typewriter` to ensure correct usage and to catch invalid prop or argument types at compile time. [[1]](diffhunk://#diff-93e8f2f992d0e1a42705b5bcef9bcebdbfc8fce93d028568ad6c38ab3959a8ceR1-R81) [[2]](diffhunk://#diff-f3408566c656e9bdab061815e65df019116151740d664a3358c3cdc7af6b7c9fR1-R94)

These changes make the APIs more intuitive and type-safe, while reducing the potential for misconfiguration.