### PR TITLE
refactor(blog): rename theme toggle

### DIFF
--- a/apps/blog/src/app/[lang]/layout.tsx
+++ b/apps/blog/src/app/[lang]/layout.tsx
@@ -25,9 +25,9 @@ import Categories from '@/components/aside/categories';
 import Links from '@/components/aside/links';
 import Profile from '@/components/aside/profile';
 
-import DarkModeToggle from '@/components/header/dark-mode-toggle';
 import DocSearch from '@/components/header/doc-search';
 import FlexContainer from '@/components/header/flex-container';
+import ThemeToggle from '@/components/header/theme-toggle';
 import Title from '@/components/header/title';
 
 import { GOOGLE_GA_ID } from '@/constants';
@@ -89,7 +89,7 @@ export default async function RootLayout({
             <Title lang={lang} />
             <FlexContainer>
               <DocSearch />
-              <DarkModeToggle />
+              <ThemeToggle />
             </FlexContainer>
           </Header>
           <Aside>

--- a/apps/blog/src/components/common/theme-context.tsx
+++ b/apps/blog/src/components/common/theme-context.tsx
@@ -55,7 +55,7 @@ export const defaultTheme = 'dark' satisfies Theme;
  *
  * @example
  * ```tsx
- * function DarkModeToggle() {
+ * function ThemeToggle() {
  *   const [theme, toggleTheme] = useThemeContext();
  *
  *   return (

--- a/apps/blog/src/components/header/theme-toggle.module.css
+++ b/apps/blog/src/components/header/theme-toggle.module.css
@@ -1,4 +1,4 @@
-.dark-mode-toggle {
+.theme-toggle {
   &:hover {
     animation: var(--animation-shake);
   }

--- a/apps/blog/src/components/header/theme-toggle.tsx
+++ b/apps/blog/src/components/header/theme-toggle.tsx
@@ -1,5 +1,5 @@
 /**
- * @fileoverview dark-mode-toggle.
+ * @fileoverview theme-toggle.
  */
 
 // --------------------------------------------------------------------------------
@@ -14,17 +14,17 @@
 
 import { cn } from '@lumir/utils';
 import { useThemeContext } from '@/components/common/theme-context';
-import styles from './dark-mode-toggle.module.css';
+import styles from './theme-toggle.module.css';
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
-export default function DarkModeToggle() {
+export default function ThemeToggle() {
   const [theme, toggleTheme] = useThemeContext();
 
   return (
-    <div className={cn(styles['dark-mode-toggle'], 'custom-flex-center')}>
+    <div className={cn(styles['theme-toggle'], 'custom-flex-center')}>
       <button
         type="button"
         className={styles.switch}


### PR DESCRIPTION
## summary

- Rename the blog header dark mode toggle component to theme toggle.
- Update imports, component naming, CSS module naming, and the theme context example to match.

## scope

- `apps/blog/src/app/[lang]/layout.tsx`
- `apps/blog/src/components/common/theme-context.tsx`
- `apps/blog/src/components/header/theme-toggle.tsx`
- `apps/blog/src/components/header/theme-toggle.module.css`

## validation

- Not run per request to create the PR without validation.
- Pre-commit `lint-staged` ran automatically during commit.

## notes

- The old `dark-mode-toggle` filenames and references were removed.