### PR TITLE
chore(blog): make `count-docs` script cross-platform

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -13,7 +13,7 @@
     "test": "node --run test:types && node --run test:unit",
     "test:types": "next typegen && tsgo -b tsconfig.app.json",
     "test:unit": "vitest run",
-    "count-docs": "ls -R src/posts/docs | grep .md | wc -l"
+    "count-docs": "node scripts/count-docs.ts"
   },
   "dependencies": {
     "@docsearch/css": "^3.9.0",

--- a/apps/blog/scripts/count-docs.ts
+++ b/apps/blog/scripts/count-docs.ts
@@ -1,0 +1,6 @@
+import { globSync } from 'node:fs';
+
+console.log(
+  'Number of docs:',
+  globSync('**/*.md', { cwd: new URL('../src/posts/docs', import.meta.url) }).length,
+);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,7 +117,7 @@ export default defineConfig([
   },
   {
     name: 'js/scripts',
-    files: ['scripts/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+    files: ['**/scripts/**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
     rules: {
       'no-console': 'off', // Allow console statements in scripts.
     },


### PR DESCRIPTION
This pull request updates the way documentation files are counted in the blog app and improves script linting coverage. The main changes include replacing the shell-based doc counting command with a Node.js script and expanding ESLint configuration to cover scripts in all subdirectories.

**Script improvements:**

* Replaced the shell command in the `count-docs` npm script with a Node.js script (`scripts/count-docs.ts`) that uses `globSync` to count `.md` files, making the process more robust and cross-platform. (`apps/blog/package.json`, [apps/blog/package.jsonL16-R16](diffhunk://#diff-cd29b0763a1190c00f640a32386d0e2b0c03f9ba4701d55e71abc1cb607d0171L16-R16))
* Added a new `scripts/count-docs.ts` script that counts markdown files in `src/posts/docs` using Node.js APIs.

**Linting configuration:**

* Updated the ESLint configuration to match scripts in any subdirectory, not just at the root, by changing the glob pattern to `**/scripts/**/*` in `eslint.config.js`.