### PR TITLE
chore(blog): use vite types for markdown loader

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -54,7 +54,6 @@
     "@lumir/types": "*",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "rolldown": "^1.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }

--- a/apps/blog/plugins/markdown-loader.js
+++ b/apps/blog/plugins/markdown-loader.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Defines Markdown loaders for Webpack, Rollup, Rolldown, and Vite.
+ * @fileoverview Defines Markdown loaders for Webpack and Vite.
  */
 
 // --------------------------------------------------------------------------------
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 /**
- * @import { Plugin } from 'rolldown';
+ * @import { Plugin } from 'vite';
  */
 
 // --------------------------------------------------------------------------------
@@ -37,13 +37,12 @@ export function markdownWebpackPlugin(source) {
 }
 
 /**
- * Creates a Rollup, Rolldown, and Vite compatible plugin
- * that loads Markdown files as default-exported strings.
- * @returns {Promise<Plugin>} A Rollup plugin for transforming `.md` files.
+ * Creates a Vite plugin that loads Markdown files as default-exported strings.
+ * @returns {Promise<Plugin>} A Vite plugin for transforming `.md` files.
  */
-export async function rollupPluginMarkdown() {
+export async function vitePluginMarkdown() {
   return {
-    name: 'rollup-plugin-markdown',
+    name: 'vite-plugin-markdown',
 
     async load(id) {
       if (id.endsWith('.md')) {

--- a/apps/blog/vitest.config.js
+++ b/apps/blog/vitest.config.js
@@ -1,9 +1,9 @@
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
-import { rollupPluginMarkdown } from './plugins/markdown-loader.js';
+import { vitePluginMarkdown } from './plugins/markdown-loader.js';
 
 export default defineConfig({
-  plugins: [rollupPluginMarkdown()],
+  plugins: [vitePluginMarkdown()],
   oxc: {
     jsx: {
       runtime: 'automatic',

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "remark-math": "^6.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
-        "sharp": "^0.35.1",
+        "sharp": "^0.35.2",
         "strip-markdown": "^6.0.0",
         "unified": "^11.0.5"
       },
@@ -85,7 +85,6 @@
         "@lumir/types": "*",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "rolldown": "^1.0.3",
         "vite": "^8.0.16",
         "vitest": "^4.1.8"
       },


### PR DESCRIPTION
This pull request removes support for Rolldown and Rollup from the Markdown loader in the blog app, focusing the loader exclusively on Vite. The relevant plugin and configuration code have been updated to reflect this change.

**Markdown Loader Refactoring:**

* Removed Rolldown and Rollup support from the Markdown loader, updating comments, imports, and type definitions to reference only Vite. (`apps/blog/plugins/markdown-loader.js`)
* Renamed the plugin export from `rollupPluginMarkdown` to `vitePluginMarkdown` and updated its implementation and references accordingly. (`apps/blog/plugins/markdown-loader.js`, `apps/blog/vitest.config.js`) [[1]](diffhunk://#diff-6a636d162396dbdd418d684a3a6834986649b9d29157335edfcbffd01eb50237L40-R45) [[2]](diffhunk://#diff-48262cde35ce384eff89ea67189a3df3999fed2b886d60d3b006247025f4be29L3-R6)

**Dependency Cleanup:**

* Removed the `rolldown` dependency from `package.json` as it is no longer needed. (`apps/blog/package.json`)