### PR TITLE
test(@lumir/rehype-plugins): use unified for rehype tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10451,23 +10451,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rehype": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "rehype-parse": "^9.0.0",
-        "rehype-stringify": "^10.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-autolink-headings": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
@@ -13111,7 +13094,9 @@
       },
       "devDependencies": {
         "@types/hast": "^3.0.4",
-        "rehype": "^13.0.2",
+        "rehype-parse": "^9.0.1",
+        "rehype-stringify": "^10.0.1",
+        "unified": "^11.0.5",
         "vitest": "^4.1.8"
       }
     },

--- a/packages/rehype-plugins/package.json
+++ b/packages/rehype-plugins/package.json
@@ -36,7 +36,9 @@
   },
   "devDependencies": {
     "@types/hast": "^3.0.4",
-    "rehype": "^13.0.2",
+    "rehype-parse": "^9.0.1",
+    "rehype-stringify": "^10.0.1",
+    "unified": "^11.0.5",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/rehype-plugins/src/rehype-image-lazy-loading.test.ts
+++ b/packages/rehype-plugins/src/rehype-image-lazy-loading.test.ts
@@ -6,8 +6,10 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { rehype } from 'rehype';
 import { assert, describe, it } from 'vitest';
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
 import { rehypeImageLazyLoading } from './rehype-image-lazy-loading.js';
 
 // --------------------------------------------------------------------------------
@@ -17,9 +19,10 @@ import { rehypeImageLazyLoading } from './rehype-image-lazy-loading.js';
 describe('rehype-image-lazy-loading', () => {
   describe('when the image does not have a loading attribute', () => {
     it('should add the `loading="lazy"` attribute', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageLazyLoading)
+        .use(rehypeStringify)
         .process('<img src="http://example.com/image.png">');
 
       assert.strictEqual(
@@ -29,9 +32,10 @@ describe('rehype-image-lazy-loading', () => {
     });
 
     it('should add the `loading="lazy"` attribute to all images', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageLazyLoading)
+        .use(rehypeStringify)
         .process(
           [
             '<img src="http://example.com/image.png">',
@@ -55,9 +59,10 @@ describe('rehype-image-lazy-loading', () => {
 
   describe('when the image already has a loading attribute', () => {
     it('should keep the original loading attribute - 1', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageLazyLoading)
+        .use(rehypeStringify)
         .process('<img src="http://example.com/image.png" loading="eager">');
 
       assert.strictEqual(
@@ -67,9 +72,10 @@ describe('rehype-image-lazy-loading', () => {
     });
 
     it('should keep the original loading attribute - 2', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageLazyLoading)
+        .use(rehypeStringify)
         .process('<img src="http://example.com/image.png" loading="auto">');
 
       assert.strictEqual(

--- a/packages/rehype-plugins/src/rehype-image-url-replace.test.ts
+++ b/packages/rehype-plugins/src/rehype-image-url-replace.test.ts
@@ -6,8 +6,10 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { rehype } from 'rehype';
 import { assert, describe, it } from 'vitest';
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
 import { rehypeImageUrlReplace } from './rehype-image-url-replace.js';
 
 // --------------------------------------------------------------------------------
@@ -17,24 +19,26 @@ import { rehypeImageUrlReplace } from './rehype-image-url-replace.js';
 describe('rehype-image-url-replace', () => {
   describe('when the image URL matches the search pattern', () => {
     it('should replace the image URL', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageUrlReplace, {
           searchValue: /^\/public/,
           replaceValue: '',
         })
+        .use(rehypeStringify)
         .process('<img src="/public/images/example.png">');
 
       assert.strictEqual(file.value, '<img src="/images/example.png">');
     });
 
     it('should replace all matching image URLs', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageUrlReplace, {
           searchValue: /^\/public/,
           replaceValue: '',
         })
+        .use(rehypeStringify)
         .process(
           [
             '<img src="/public/images/example-1.png">',
@@ -56,12 +60,13 @@ describe('rehype-image-url-replace', () => {
     });
 
     it('should handle `y` flag in the search pattern', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageUrlReplace, {
           searchValue: /^\/public/y,
           replaceValue: '',
         })
+        .use(rehypeStringify)
         .process('<img src="/public/images/example.png">');
 
       assert.strictEqual(file.value, '<img src="/images/example.png">');
@@ -70,12 +75,13 @@ describe('rehype-image-url-replace', () => {
 
   describe('when the image URL does not match the search pattern', () => {
     it('should keep the original image URL', async () => {
-      const file = await rehype()
-        .data('settings', { fragment: true })
+      const file = await unified()
+        .use(rehypeParse, { fragment: true })
         .use(rehypeImageUrlReplace, {
           searchValue: /^\/public/,
           replaceValue: '',
         })
+        .use(rehypeStringify)
         .process('<img src="/assets/example.png">');
 
       assert.strictEqual(file.value, '<img src="/assets/example.png">');


### PR DESCRIPTION
This pull request updates the test setup for the rehype plugins to use the `unified` processing pipeline directly, along with explicit `rehype-parse` and `rehype-stringify` plugins, instead of the deprecated `rehype` package. The changes modernize the test code and dependencies for better compatibility and maintainability.

**Dependency updates:**

- Replaced the `rehype` dependency with `unified`, `rehype-parse`, and `rehype-stringify` in `package.json` to align with current best practices for processing HTML with rehype plugins.

**Test code modernization:**

- Updated all test files (`rehype-image-lazy-loading.test.ts`, `rehype-image-url-replace.test.ts`) to use the new `unified` pipeline, explicitly including `rehype-parse` and `rehype-stringify` in the processing chain instead of relying on the old `rehype()` API. [[1]](diffhunk://#diff-a3e16c2f2891a3d0a3c1864c3441a707541fba6094ca5ebc9890cc16e01c1e9aL9-R12) [[2]](diffhunk://#diff-a3e16c2f2891a3d0a3c1864c3441a707541fba6094ca5ebc9890cc16e01c1e9aL20-R25) [[3]](diffhunk://#diff-a3e16c2f2891a3d0a3c1864c3441a707541fba6094ca5ebc9890cc16e01c1e9aL32-R38) [[4]](diffhunk://#diff-a3e16c2f2891a3d0a3c1864c3441a707541fba6094ca5ebc9890cc16e01c1e9aL58-R65) [[5]](diffhunk://#diff-a3e16c2f2891a3d0a3c1864c3441a707541fba6094ca5ebc9890cc16e01c1e9aL70-R78) [[6]](diffhunk://#diff-c169f1fd3e8f51ebfea6cf5e33dcf1ed13623b6c8f6422728a74ce9f44ebf695L9-R12) [[7]](diffhunk://#diff-c169f1fd3e8f51ebfea6cf5e33dcf1ed13623b6c8f6422728a74ce9f44ebf695L20-R41) [[8]](diffhunk://#diff-c169f1fd3e8f51ebfea6cf5e33dcf1ed13623b6c8f6422728a74ce9f44ebf695L59-R69) [[9]](diffhunk://#diff-c169f1fd3e8f51ebfea6cf5e33dcf1ed13623b6c8f6422728a74ce9f44ebf695L73-R84)