### PR TITLE
fix(blog): replace `next/image` with plain `<img>` for static export to reduce bundle size

### DIFF
--- a/apps/blog/src/components/aside/profile.tsx
+++ b/apps/blog/src/components/aside/profile.tsx
@@ -27,7 +27,18 @@ export default async function Profile({ lang }: PropsWithLang) {
 
   return (
     <div className={cn(styles.profile, 'custom-flex-center')}>
-      <img src={avatarUrl} width={96} height={96} alt={`${name}'s GitHub profile`} />
+      <img
+        src={(() => {
+          // To avoid downloading a much larger image than needed,
+          // we can add a query parameter to the avatar URL to request a smaller size.
+          const url = new URL(avatarUrl);
+          url.searchParams.set('s', '96');
+          return url.toString();
+        })()}
+        width={96}
+        height={96}
+        alt={`${name}'s GitHub profile`}
+      />
       <div className={styles['user-name']}>
         <Link href={`/${lang}`}>{name}</Link>
       </div>

--- a/apps/blog/src/components/aside/profile.tsx
+++ b/apps/blog/src/components/aside/profile.tsx
@@ -12,7 +12,6 @@ import 'server-only';
 // Import
 // --------------------------------------------------------------------------------
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@lumir/utils';
 import { type PropsWithLang } from '@/data/lang';
@@ -28,12 +27,7 @@ export default async function Profile({ lang }: PropsWithLang) {
 
   return (
     <div className={cn(styles.profile, 'custom-flex-center')}>
-      <Image
-        src={avatarUrl}
-        width={96}
-        height={96}
-        alt={`${name}'s GitHub profile image`}
-      />
+      <img src={avatarUrl} width={96} height={96} alt={`${name}'s GitHub profile`} />
       <div className={styles['user-name']}>
         <Link href={`/${lang}`}>{name}</Link>
       </div>

--- a/apps/blog/src/components/common/loading.tsx
+++ b/apps/blog/src/components/common/loading.tsx
@@ -6,7 +6,6 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import Image from 'next/image';
 import { cn } from '@lumir/utils';
 import styles from './loading.module.css';
 
@@ -19,12 +18,11 @@ export default function Loading({ content }: { content: string }) {
     <div className={cn(styles.loading, 'custom-flex-center')}>
       <div className="custom-flex-center">
         <div>
-          <Image
+          <img
             src="/images/loading.gif"
             width={48}
             height={48}
-            alt="GitHub GIF loading image"
-            unoptimized
+            alt="GitHub GIF loading"
           />
         </div>
         <div className={styles.content}>{content} 불러오는 중...</div>

--- a/apps/blog/src/components/header/title.tsx
+++ b/apps/blog/src/components/header/title.tsx
@@ -12,7 +12,6 @@ import 'server-only';
 // Import
 // --------------------------------------------------------------------------------
 
-import Image from 'next/image';
 import Link from 'next/link';
 import { cn } from '@lumir/utils';
 import { type PropsWithLang } from '@/data/lang';
@@ -29,12 +28,7 @@ export default async function Title({ lang }: PropsWithLang) {
   return (
     <div className={cn(styles.title, 'custom-flex-center')}>
       <Link href={`/${lang}`}>
-        <Image
-          src={avatarUrl}
-          width={40}
-          height={40}
-          alt={`${name}'s GitHub profile image`}
-        />
+        <img src={avatarUrl} width={40} height={40} alt={`${name}'s GitHub profile`} />
       </Link>
 
       <div>

--- a/apps/blog/src/components/header/title.tsx
+++ b/apps/blog/src/components/header/title.tsx
@@ -28,7 +28,18 @@ export default async function Title({ lang }: PropsWithLang) {
   return (
     <div className={cn(styles.title, 'custom-flex-center')}>
       <Link href={`/${lang}`}>
-        <img src={avatarUrl} width={40} height={40} alt={`${name}'s GitHub profile`} />
+        <img
+          src={(() => {
+            // To avoid downloading a much larger image than needed,
+            // we can add a query parameter to the avatar URL to request a smaller size.
+            const url = new URL(avatarUrl);
+            url.searchParams.set('s', '40');
+            return url.toString();
+          })()}
+          width={40}
+          height={40}
+          alt={`${name}'s GitHub profile`}
+        />
       </Link>
 
       <div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,7 +84,17 @@ export default defineConfig([
       },
     },
     rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          name: 'next/image',
+          importNames: ['default'],
+          message:
+            "Use a plain `<img>` element instead of Next.js' Image component for static exports. Next.js image optimization isn't applied during static export.",
+        },
+      ],
       'react/no-unknown-property': 'off', // TypeScript handles this. TODO: Remove this in shared config.
+      '@next/next/no-img-element': 'off', // Plain `<img>` is intentional because static export doesn't use Next image optimization.
     },
   },
   {


### PR DESCRIPTION
This pull request updates several components to use the standard HTML `<img>` element instead of Next.js' `Image` component for rendering images. The changes are motivated by the need to ensure correct image rendering during static exports, as Next.js image optimization is not applied in that context. To enforce this practice, a new ESLint rule is also introduced. The most important changes are as follows:

**Component Refactoring:**

* Replaced all usages of the `next/image` `Image` component with the standard `<img>` element in `profile.tsx`, `title.tsx`, and `loading.tsx`, ensuring compatibility with static exports. [[1]](diffhunk://#diff-6fe156736eed551169cd5dbe503c67d60619cb62df593a221679d3650bd97ad1L31-R30) [[2]](diffhunk://#diff-abda050db9cece29311f40ef27f1602bb511dd7a03129ddd597db74a0c6987fbL32-R31) [[3]](diffhunk://#diff-be134a645d537ff94c8e45fe0edbf8b90b21a4fd9d86c218dc0cccb61596c4d3L22-R25)

* Removed unused imports of `next/image` from affected component files. [[1]](diffhunk://#diff-6fe156736eed551169cd5dbe503c67d60619cb62df593a221679d3650bd97ad1L15) [[2]](diffhunk://#diff-abda050db9cece29311f40ef27f1602bb511dd7a03129ddd597db74a0c6987fbL15) [[3]](diffhunk://#diff-be134a645d537ff94c8e45fe0edbf8b90b21a4fd9d86c218dc0cccb61596c4d3L9)

**Linting and Code Quality:**

* Added a `no-restricted-imports` ESLint rule to prevent importing `next/image` and provide a clear message to use `<img>` for static exports.

* Disabled the `@next/next/no-img-element` ESLint rule to allow intentional use of `<img>` elements in the codebase.