### PR TITLE
chore(*): update `vercel-ignore-command` to ignore dependabot PRs

### DIFF
--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -2,7 +2,6 @@
   "buildCommand": "node --run count-docs && node --run build",
   "cleanUrls": true,
   "framework": null,
-  "ignoreCommand": "node ../../scripts/vercel-ignore-command.ts",
   "installCommand": "npm install --no-audit --no-fund --prefer-offline --prefix ../..",
   "outputDirectory": "build",
   "regions": ["icn1"],

--- a/scripts/vercel-ignore-command.ts
+++ b/scripts/vercel-ignore-command.ts
@@ -1,11 +1,26 @@
+/**
+ * @fileoverview Script to tell Vercel whether to skip a build.
+ */
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
 const author = process.env.VERCEL_GIT_COMMIT_AUTHOR_LOGIN;
 const branch = process.env.VERCEL_GIT_COMMIT_REF;
 
-// If the branch is `gh-pages`, ignore the build.
-if (branch === 'gh-pages') {
-  console.log(`🛑 Ignoring build for this branch (author: ${author}, branch: ${branch})`);
+// --------------------------------------------------------------------------------
+// Script
+// --------------------------------------------------------------------------------
+
+// If the PR is created by `dependabot[bot]` and the branch is not `main`, ignore the build.
+if (author === 'dependabot[bot]' && branch !== 'main') {
+  console.log(
+    `🛑 Ignoring build for dependabot[bot] PR (author: ${author}, branch: ${branch})`,
+  );
   process.exit(0); // Return `0` to skip the build.
 }
 
+// Proceed with the build in other cases.
 console.log(`✅ Proceeding with the build (author: ${author}, branch: ${branch})`);
 process.exit(1); // Return `1` to proceed with the build.


### PR DESCRIPTION
This pull request updates the Vercel build ignore logic for the blog app. The main change is to refine when builds are skipped, specifically to ignore builds triggered by Dependabot on non-main branches, and to remove the previous ignore command from the Vercel configuration.

Build process changes:

* Updated `scripts/vercel-ignore-command.ts` to skip builds only for pull requests created by `dependabot[bot]` on branches other than `main`, instead of ignoring builds on the `gh-pages` branch.
* Removed the `ignoreCommand` entry from `apps/blog/vercel.json`, so Vercel will no longer reference this script directly in its configuration.