### PR TITLE
refactor(*): use effect-local `requestAnimationFrame` ids

### DIFF
--- a/apps/blog/src/components/header/scroll-progress.tsx
+++ b/apps/blog/src/components/header/scroll-progress.tsx
@@ -34,11 +34,11 @@ export default function ScrollProgress() {
       return undefined;
     }
 
-    let raf: number | null = null;
+    let rafId: number | null = null;
 
     function requestProgressUpdate() {
-      if (!raf) {
-        raf = requestAnimationFrame(() => {
+      if (!rafId) {
+        rafId = requestAnimationFrame(() => {
           const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
           const progress = maxScroll > 0 ? window.scrollY / maxScroll : 0;
           const roundedProgress = Math.round(progress * 1000) / 1000;
@@ -46,7 +46,7 @@ export default function ScrollProgress() {
 
           scrollProgressRef.current!.style.transform = `scaleX(${clampedProgress})`;
 
-          raf = null;
+          rafId = null;
         });
       }
     }
@@ -57,9 +57,8 @@ export default function ScrollProgress() {
     window.addEventListener('resize', requestProgressUpdate);
 
     return () => {
-      if (raf !== null) {
-        cancelAnimationFrame(raf);
-        raf = null;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
       }
 
       window.removeEventListener('scroll', requestProgressUpdate);

--- a/packages/react-kit/src/hooks/use-typewriter.ts
+++ b/packages/react-kit/src/hooks/use-typewriter.ts
@@ -6,7 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { useEffect, useEffectEvent, useRef, useState } from 'react';
+import { useEffect, useEffectEvent, useState } from 'react';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -151,12 +151,12 @@ export function useTypewriter(
     onEraseCompleteProp?.();
   });
 
-  const rafRef = useRef<number | null>(null); // TODO: use closure instead?
-
   useEffect(() => {
     if (pause) {
       return undefined;
     }
+
+    let rafId: number | null = null;
 
     /** Minimal helper to emulate `setTimeout` with rAF(requestAnimationFrame) */
     const setTimeoutRaf = (callback: () => void, delay: number) => {
@@ -164,15 +164,15 @@ export function useTypewriter(
 
       const step = (timestamp: number) => {
         if (timestamp - base >= delay) {
-          rafRef.current = null;
+          rafId = null;
           callback();
           return;
         }
 
-        rafRef.current = requestAnimationFrame(step);
+        rafId = requestAnimationFrame(step);
       };
 
-      rafRef.current = requestAnimationFrame(step);
+      rafId = requestAnimationFrame(step);
     };
 
     if (currentMode === 'write') {
@@ -212,9 +212,8 @@ export function useTypewriter(
     }
 
     return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
       }
     };
   }, [


### PR DESCRIPTION
This pull request refactors the management of animation frame IDs in both the `ScrollProgress` component and the `useTypewriter` hook, replacing the use of `useRef` with a simpler local variable approach for better clarity and correctness. Additionally, an unused import is removed from the `use-typewriter` hook.

**Refactoring animation frame management:**

* [`apps/blog/src/components/header/scroll-progress.tsx`](diffhunk://#diff-c76b0497c18cd6a5a02ee5203d666613a6fa7ea705da6c7b4cde11e4f74847edL37-R49): Replaces the `raf` variable with `rafId`, ensuring consistent naming and correct cancellation of animation frames in the cleanup function. [[1]](diffhunk://#diff-c76b0497c18cd6a5a02ee5203d666613a6fa7ea705da6c7b4cde11e4f74847edL37-R49) [[2]](diffhunk://#diff-c76b0497c18cd6a5a02ee5203d666613a6fa7ea705da6c7b4cde11e4f74847edL60-R61)
* [`packages/react-kit/src/hooks/use-typewriter.ts`](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L154-R175): Removes the `rafRef` ref in favor of a local `rafId` variable, simplifying the animation frame management and improving code clarity. [[1]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L154-R175) [[2]](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L215-R216)

**Code cleanup:**

* [`packages/react-kit/src/hooks/use-typewriter.ts`](diffhunk://#diff-b5e6224834b74fd545fc96aa4a2c7fcd37a41d05aa4f9d80eb85e39ddb61e508L9-R9): Removes an unused `useRef` import.