### PR TITLE
refactor(@lumir/react-kit): simplify `use-toggle` overload type signature

### DIFF
--- a/packages/react-kit/src/hooks/use-toggle.test.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test.ts
@@ -15,7 +15,7 @@ import { useToggle } from './use-toggle.js';
 // --------------------------------------------------------------------------------
 
 describe('use-toggle', () => {
-  // First overload: `useToggle()`
+  // Boolean toggle: `useToggle()`
   it('Default initial value should be `false` when not provided', async () => {
     const { result } = await renderHook(() => useToggle());
     const [state, toggle] = result.current;
@@ -48,7 +48,7 @@ describe('use-toggle', () => {
     assert.strictEqual(thirdState, false);
   });
 
-  // Second overload: `useToggle(initialValue)`
+  // Boolean toggle: `useToggle(initialValue)`
   it('Initial value should be `true` when provided', async () => {
     const { result } = await renderHook(() => useToggle(true));
     const [state, toggle] = result.current;
@@ -81,7 +81,7 @@ describe('use-toggle', () => {
     assert.strictEqual(thirdState, true);
   });
 
-  // Third overload: `useToggle(initialValue, firstValue, secondValue)`
+  // Explicit value toggle: `useToggle(initialValue, firstValue, secondValue)`
   it('Initial value should be used as the initial state value when three values are provided', async () => {
     const { result } = await renderHook(() => useToggle('open', 'closed', 'open'));
     const [state, toggle] = result.current;

--- a/packages/react-kit/src/hooks/use-toggle.ts
+++ b/packages/react-kit/src/hooks/use-toggle.ts
@@ -15,40 +15,17 @@ import { useCallback, useState } from 'react';
 
 /**
  * `useToggle` is a React hook that simplifies managing a boolean state.
- * It initializes the state to `false` and provides a function to toggle it
- * between `true` and `false`.
+ * It initializes the state to `false` by default, or with the provided boolean
+ * value, and provides a function to toggle it between `true` and `false`.
  *
+ * @param initialValue The optional initial boolean state value. (default: `false`)
  * @returns Current boolean state and a function that toggles it.
  * @example
  * ```tsx
  * import { useToggle } from '@lumir/react-kit/hooks';
  *
  * function Component() {
- *   const [isOpen, toggleIsOpen] = useToggle();
- *
- *   return (
- *     <button type="button" onClick={toggleIsOpen}>
- *       {isOpen ? 'Close' : 'Open'}
- *     </button>
- *   );
- * }
- * ```
- */
-export function useToggle(): readonly [state: boolean, toggle: () => void];
-
-/**
- * `useToggle` is a React hook that simplifies managing a boolean state.
- * It initializes the state with the provided boolean value and provides a
- * function to toggle it between `true` and `false`.
- *
- * @param initialValue The initial boolean state value.
- * @returns Current boolean state and a function that toggles it.
- * @example
- * ```tsx
- * import { useToggle } from '@lumir/react-kit/hooks';
- *
- * function Component() {
- *   const [isOpen, toggleIsOpen] = useToggle(false);
+ *   const [isOpen, toggleIsOpen] = useToggle(); // You can also pass an initial value: `useToggle(true)`
  *
  *   return (
  *     <button type="button" onClick={toggleIsOpen}>
@@ -59,7 +36,7 @@ export function useToggle(): readonly [state: boolean, toggle: () => void];
  * ```
  */
 export function useToggle(
-  initialValue: boolean,
+  initialValue?: boolean,
 ): readonly [state: boolean, toggle: () => void];
 
 /**


### PR DESCRIPTION
This pull request refines the `useToggle` hook and its associated tests for clarity and improved usability. The main updates include clearer documentation, improved parameter handling, and more descriptive test comments.

**Documentation and API improvements:**

* Updated the JSDoc for `useToggle` to clarify its default behavior, explicitly document the `initialValue` parameter as optional, and simplify usage examples.
* Changed the `useToggle` function signature to make `initialValue` optional, defaulting to `false` if not provided.

**Testing improvements:**

* Reworded test descriptions in `use-toggle.test.ts` to more clearly indicate the overloads and use cases being tested (e.g., "Boolean toggle" and "Explicit value toggle"). [[1]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L18-R18) [[2]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L51-R51) [[3]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L84-R84)