### PR TITLE
feat(@lumir/react-kit)!: use options object for `useToggle` values

### DIFF
--- a/apps/blog/src/components/common/theme-context.tsx
+++ b/apps/blog/src/components/common/theme-context.tsx
@@ -117,8 +117,7 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
       return (document.documentElement.getAttribute(themeKey) ?? defaultTheme) as Theme;
     },
-    'dark',
-    'light',
+    { firstValue: 'dark', secondValue: 'light' },
   );
 
   useEffect(() => {

--- a/packages/react-kit/src/hooks/use-toggle.test-d.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test-d.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Type test for `use-toggle.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useToggle, type UseToggleOptions } from './use-toggle.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region UseToggleOptions
+
+let options: UseToggleOptions<'dark' | 'light'>;
+
+options = { firstValue: 'dark', secondValue: 'light' };
+options = { firstValue: 'light', secondValue: 'dark' };
+
+// @ts-expect-error - `firstValue` is required.
+options = { secondValue: 'light' };
+// @ts-expect-error - `secondValue` is required.
+options = { firstValue: 'dark' };
+// @ts-expect-error - `firstValue` should match the toggle value type.
+options = { firstValue: 'system', secondValue: 'light' };
+// @ts-expect-error - `secondValue` should match the toggle value type.
+options = { firstValue: 'dark', secondValue: 'system' };
+// @ts-expect-error - `unknown` is not a valid property of `UseToggleOptions`.
+options = { firstValue: 'dark', secondValue: 'light', unknown: 'unknown' };
+
+// #endregion UseToggleOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useToggle
+
+({}) as typeof useToggle satisfies Function;
+
+// @ts-expect-error - `useToggle` should be a function.
+({}) as typeof useToggle satisfies boolean;
+// @ts-expect-error - `useToggle` should be a function.
+({}) as typeof useToggle satisfies string;
+
+function useToggleTypeTest() {
+  useToggle();
+  useToggle(false);
+  useToggle(true);
+  useToggle('open', { firstValue: 'closed', secondValue: 'open' });
+  useToggle(() => 'open', { firstValue: 'closed', secondValue: 'open' });
+  useToggle<'dark' | 'light'>('light', { firstValue: 'dark', secondValue: 'light' });
+
+  const [bool, toggleBool] = useToggle();
+  bool satisfies boolean;
+  toggleBool satisfies () => void;
+
+  const [theme, toggleTheme] = useToggle<'dark' | 'light'>('light', {
+    firstValue: 'dark',
+    secondValue: 'light',
+  });
+  theme satisfies 'dark' | 'light';
+  toggleTheme satisfies () => void;
+
+  // @ts-expect-error - Explicit values should be passed as options.
+  useToggle('open', 'closed', 'open');
+  // @ts-expect-error - `initialValue` should be boolean when options are omitted.
+  useToggle('open');
+  // @ts-expect-error - `initialValue` should match the toggle value type.
+  useToggle<'dark' | 'light'>('system', { firstValue: 'dark', secondValue: 'light' });
+  // @ts-expect-error - `firstValue` should match the toggle value type.
+  useToggle<'dark' | 'light'>('light', { firstValue: 'system', secondValue: 'light' });
+  // @ts-expect-error - `secondValue` should match the toggle value type.
+  useToggle<'dark' | 'light'>('light', { firstValue: 'dark', secondValue: 'system' });
+  // @ts-expect-error - Options should include `firstValue`.
+  useToggle('open', { secondValue: 'closed' });
+  // @ts-expect-error - Options should include `secondValue`.
+  useToggle('open', { firstValue: 'open' });
+}
+
+// #endregion useToggle
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-toggle.test.ts
+++ b/packages/react-kit/src/hooks/use-toggle.test.ts
@@ -81,17 +81,21 @@ describe('use-toggle', () => {
     assert.strictEqual(thirdState, true);
   });
 
-  // Explicit value toggle: `useToggle(initialValue, firstValue, secondValue)`
-  it('Initial value should be used as the initial state value when three values are provided', async () => {
-    const { result } = await renderHook(() => useToggle('open', 'closed', 'open'));
+  // Explicit value toggle: `useToggle(initialValue, options)`
+  it('Initial value should be used as the initial state value when options are provided', async () => {
+    const { result } = await renderHook(() =>
+      useToggle('open', { firstValue: 'closed', secondValue: 'open' }),
+    );
     const [state, toggle] = result.current;
 
     assert.strictEqual(state, 'open');
     assert.strictEqual(typeof toggle, 'function');
   });
 
-  it('Initial value function should be used as the initial state value when three values are provided', async () => {
-    const { result } = await renderHook(() => useToggle(() => 'open', 'closed', 'open'));
+  it('Initial value function should be used as the initial state value when options are provided', async () => {
+    const { result } = await renderHook(() =>
+      useToggle(() => 'open', { firstValue: 'closed', secondValue: 'open' }),
+    );
     const [state, toggle] = result.current;
 
     assert.strictEqual(state, 'open');
@@ -100,7 +104,7 @@ describe('use-toggle', () => {
 
   it('`toggle` function should toggle between the provided state values', async () => {
     const { act, result } = await renderHook(() =>
-      useToggle<'dark' | 'light'>('light', 'dark', 'light'),
+      useToggle<'dark' | 'light'>('light', { firstValue: 'dark', secondValue: 'light' }),
     );
 
     const [firstState, toggle] = result.current;

--- a/packages/react-kit/src/hooks/use-toggle.ts
+++ b/packages/react-kit/src/hooks/use-toggle.ts
@@ -10,6 +10,25 @@
 import { useCallback, useState } from 'react';
 
 // --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Options for toggling between two explicit values.
+ */
+export interface UseToggleOptions<T> {
+  /**
+   * The first state value.
+   */
+  firstValue: T;
+
+  /**
+   * The second state value to toggle to.
+   */
+  secondValue: T;
+}
+
+// --------------------------------------------------------------------------------
 // Overload
 // --------------------------------------------------------------------------------
 
@@ -46,8 +65,7 @@ export function useToggle(
  * first and second value.
  *
  * @param initialValue The initial state value or a function that returns it.
- * @param firstValue The first state value.
- * @param secondValue The second state value to toggle to.
+ * @param options Explicit values used for toggling.
  * @returns Current state and a function that toggles it.
  * @example
  * ```tsx
@@ -56,7 +74,10 @@ export function useToggle(
  * type Theme = 'dark' | 'light';
  *
  * function Component() {
- *   const [theme, toggleTheme] = useToggle<Theme>(() => 'light', 'dark', 'light');
+ *   const [theme, toggleTheme] = useToggle<Theme>(() => 'light', {
+ *     firstValue: 'dark',
+ *     secondValue: 'light',
+ *   });
  *
  *   return (
  *     <button type="button" onClick={toggleTheme}>
@@ -68,8 +89,7 @@ export function useToggle(
  */
 export function useToggle<const T>(
   initialValue: NoInfer<T> | (() => NoInfer<T>),
-  firstValue: T,
-  secondValue: T,
+  options: UseToggleOptions<T>,
 ): readonly [state: T, toggle: () => void];
 
 // --------------------------------------------------------------------------------
@@ -78,12 +98,12 @@ export function useToggle<const T>(
 
 export function useToggle<const T>(
   initialValue: boolean | T | (() => T) = false,
-  ...rest: [] | [firstValue: T, secondValue: T]
+  options?: UseToggleOptions<T>,
 ): readonly [state: boolean | T, toggle: () => void] {
   const [state, setState] = useState<boolean | T>(initialValue);
 
-  const firstValue = rest.length === 2 ? rest[0] : !!initialValue;
-  const secondValue = rest.length === 2 ? rest[1] : !initialValue;
+  const firstValue = options === undefined ? !!initialValue : options.firstValue;
+  const secondValue = options === undefined ? !initialValue : options.secondValue;
 
   const toggle = useCallback(() => {
     setState(prevState => (Object.is(prevState, secondValue) ? firstValue : secondValue));


### PR DESCRIPTION
This pull request updates the `useToggle` React hook and its usage to improve type safety and clarity by replacing the old positional arguments with an explicit options object. It also adds comprehensive type tests and updates all related usages and documentation accordingly.

**API and Implementation Changes:**

* Refactored the `useToggle` hook to accept an options object (`UseToggleOptions`) with `firstValue` and `secondValue` properties instead of separate positional arguments for toggling between explicit values. [[1]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acR12-R30) [[2]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL49-R68) [[3]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL59-R80) [[4]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL71-R92) [[5]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL81-R106)
* Updated the implementation logic to use the new options object, improving code readability and type safety.

**Type Safety and Testing:**

* Added a new type test file `use-toggle.test-d.ts` to verify correct usage and type errors for the `useToggle` hook and its options.

**Documentation and Usage Updates:**

* Updated all usage examples, comments, and tests to use the new options object syntax for the `useToggle` hook, replacing the old three-argument form. [[1]](diffhunk://#diff-23aaa9d26d94254a8b8014181bb6fa5d2498665883121f0742c95320456f90acL59-R80) [[2]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L84-R98) [[3]](diffhunk://#diff-061ca55e01e775541f263944175125ca7cd89f1d144f17cf92f6716a0bd57c24L103-R107) [[4]](diffhunk://#diff-e380da07859ef8b8bd720fced3d8ec9f305471190a2162c097359cff3c709b48L120-R120)