### PR TITLE
fix(@lumir/react-kit): align useBooleanState action order with `use-toggle`

### DIFF
--- a/packages/react-kit/src/hooks/use-boolean-state.test-d.ts
+++ b/packages/react-kit/src/hooks/use-boolean-state.test-d.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Type test for `use-boolean-state.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useBooleanState } from './use-boolean-state.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useBooleanState
+
+({}) as typeof useBooleanState satisfies Function;
+({}) as Parameters<typeof useBooleanState>[0] satisfies boolean | undefined;
+({}) as ReturnType<typeof useBooleanState> satisfies readonly [
+  boolean,
+  () => void,
+  () => void,
+  () => void,
+];
+
+// @ts-expect-error - `useBooleanState` should be a function.
+({}) as typeof useBooleanState satisfies boolean;
+// @ts-expect-error - `useBooleanState` should be a function.
+({}) as typeof useBooleanState satisfies string;
+
+function useBooleanStateTypeTest() {
+  useBooleanState();
+  useBooleanState(false);
+  useBooleanState(true);
+  useBooleanState(undefined);
+
+  // @ts-expect-error - `initialValue` should be a boolean.
+  useBooleanState('false');
+  // @ts-expect-error - `initialValue` should be a boolean.
+  useBooleanState(0);
+  // @ts-expect-error - `useBooleanState` accepts only one argument.
+  useBooleanState(false, true);
+}
+
+// #endregion useBooleanState
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-boolean-state.test.ts
+++ b/packages/react-kit/src/hooks/use-boolean-state.test.ts
@@ -17,28 +17,52 @@ import { useBooleanState } from './use-boolean-state.js';
 describe('use-boolean-state', () => {
   it('Default initial value should be `false` when not provided', async () => {
     const { result } = await renderHook(() => useBooleanState());
-    const [state, setTrue, setFalse, toggle] = result.current;
+    const [state, toggle, setTrue, setFalse] = result.current;
 
     assert.strictEqual(state, false);
+    assert.strictEqual(typeof toggle, 'function');
     assert.strictEqual(typeof setTrue, 'function');
     assert.strictEqual(typeof setFalse, 'function');
-    assert.strictEqual(typeof toggle, 'function');
   });
 
   it('Initial value should be `true` when provided', async () => {
     const { result } = await renderHook(() => useBooleanState(true));
-    const [state, setTrue, setFalse, toggle] = result.current;
+    const [state, toggle, setTrue, setFalse] = result.current;
 
     assert.strictEqual(state, true);
+    assert.strictEqual(typeof toggle, 'function');
     assert.strictEqual(typeof setTrue, 'function');
     assert.strictEqual(typeof setFalse, 'function');
-    assert.strictEqual(typeof toggle, 'function');
+  });
+
+  it('`toggle` function should toggle the state value', async () => {
+    const { act, result } = await renderHook(() => useBooleanState(false));
+
+    const [firstState, toggle] = result.current;
+
+    assert.strictEqual(firstState, false);
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [secondState] = result.current;
+
+    assert.strictEqual(secondState, true);
+
+    await act(async () => {
+      toggle();
+    });
+
+    const [thirdState] = result.current;
+
+    assert.strictEqual(thirdState, false);
   });
 
   it('`setTrue` function should set the state value to `true`', async () => {
     const { act, result } = await renderHook(() => useBooleanState(false));
 
-    const [firstState, setTrue] = result.current;
+    const [firstState, , setTrue] = result.current;
 
     assert.strictEqual(firstState, false);
 
@@ -63,7 +87,7 @@ describe('use-boolean-state', () => {
   it('`setFalse` function should set the state value to `false`', async () => {
     const { act, result } = await renderHook(() => useBooleanState(true));
 
-    const [firstState, , setFalse] = result.current;
+    const [firstState, , , setFalse] = result.current;
 
     assert.strictEqual(firstState, true);
 
@@ -82,30 +106,6 @@ describe('use-boolean-state', () => {
     const [thirdState] = result.current;
 
     // should remain `false` when `setFalse` is called again
-    assert.strictEqual(thirdState, false);
-  });
-
-  it('`toggle` function should toggle the state value', async () => {
-    const { act, result } = await renderHook(() => useBooleanState(false));
-
-    const [firstState, , , toggle] = result.current;
-
-    assert.strictEqual(firstState, false);
-
-    await act(async () => {
-      toggle();
-    });
-
-    const [secondState] = result.current;
-
-    assert.strictEqual(secondState, true);
-
-    await act(async () => {
-      toggle();
-    });
-
-    const [thirdState] = result.current;
-
     assert.strictEqual(thirdState, false);
   });
 });

--- a/packages/react-kit/src/hooks/use-boolean-state.ts
+++ b/packages/react-kit/src/hooks/use-boolean-state.ts
@@ -16,13 +16,13 @@ import { useCallback, useState } from 'react';
  * `useBooleanState` hook to manage a boolean state with utility functions.
  *
  * @param initialValue The initial boolean state value. Default is `false`.
- * @returns A tuple containing the current boolean value, a function to set it to `true`, a function to set it to `false`, and a function to toggle it.
+ * @returns A tuple containing the current boolean value, a function to toggle it, a function to set it to `true`, and a function to set it to `false`, in that order.
  * @example
  * ```tsx
  * import { useBooleanState } from '@lumir/react-kit/hooks';
  *
  * function Component() {
- *   const [isVisible, showIsVisible, hideIsVisible, toggleIsVisible] = useBooleanState(false);
+ *   const [isVisible, toggleIsVisible, showIsVisible, hideIsVisible] = useBooleanState(false);
  *   // Your component logic here...
  * }
  * ```
@@ -31,11 +31,15 @@ export function useBooleanState(
   initialValue = false,
 ): readonly [
   state: boolean,
+  toggle: () => void,
   setTrue: () => void,
   setFalse: () => void,
-  toggle: () => void,
 ] {
   const [state, setState] = useState<boolean>(initialValue);
+
+  const toggle = useCallback(() => {
+    setState(prevState => !prevState);
+  }, []);
 
   const setTrue = useCallback(() => {
     setState(true);
@@ -45,9 +49,5 @@ export function useBooleanState(
     setState(false);
   }, []);
 
-  const toggle = useCallback(() => {
-    setState(prevState => !prevState);
-  }, []);
-
-  return [state, setTrue, setFalse, toggle] as const;
+  return [state, toggle, setTrue, setFalse] as const;
 }


### PR DESCRIPTION
This pull request refactors the `useBooleanState` React hook to change the order of its returned tuple, updates related documentation and tests, and adds a type test file for improved type safety. The most important changes are summarized below:

### API Change and Documentation

* The return value of the `useBooleanState` hook is reordered: it now returns `[state, toggle, setTrue, setFalse]` instead of `[state, setTrue, setFalse, toggle]`. All documentation and usage examples have been updated to reflect this new order. [[1]](diffhunk://#diff-ade8f2ed2e2e7359956c3e81f9fb79220a4ff0505283a55072fd26f32f98494eL19-R25) [[2]](diffhunk://#diff-ade8f2ed2e2e7359956c3e81f9fb79220a4ff0505283a55072fd26f32f98494eR34-R43) [[3]](diffhunk://#diff-ade8f2ed2e2e7359956c3e81f9fb79220a4ff0505283a55072fd26f32f98494eL48-R52)

### Tests Update

* The tests in `use-boolean-state.test.ts` have been updated to match the new tuple order and to ensure correct behavior of the renamed and reordered functions.

### Type Safety

* A new type test file `use-boolean-state.test-d.ts` has been added to verify the type signature of the hook and ensure correct usage and error reporting at compile time.