### PR TITLE
fix(@lumir/react-kit): align `useScroll` types with DOM scroll APIs

### DIFF
--- a/packages/react-kit/src/hooks/use-scroll.test-d.ts
+++ b/packages/react-kit/src/hooks/use-scroll.test-d.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Type test for `use-scroll.ts`
+ */
+
+/* global ScrollOptions:readonly, ScrollIntoViewOptions:readonly, ScrollToOptions:readonly */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import type { RefObject } from 'react';
+import { useScroll } from './use-scroll.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useScroll
+
+({}) as typeof useScroll satisfies Function;
+({}) as Parameters<typeof useScroll>[0] satisfies ScrollOptions | undefined;
+({}) as ReturnType<typeof useScroll> satisfies readonly [
+  RefObject<HTMLElement | null>,
+  {
+    intoView: (scrollIntoViewOptions?: ScrollIntoViewOptions) => void;
+    to: (scrollToOptions?: ScrollToOptions) => void;
+  },
+];
+
+// @ts-expect-error - `useScroll` should be a function.
+({}) as typeof useScroll satisfies boolean;
+// @ts-expect-error - `useScroll` should be a function.
+({}) as typeof useScroll satisfies string;
+
+function useScrollTypeTest() {
+  useScroll();
+  useScroll(undefined);
+  useScroll({});
+  useScroll({ behavior: 'auto' });
+  useScroll({ behavior: 'instant' });
+  useScroll({ behavior: 'smooth' });
+  useScroll<HTMLDivElement>();
+  useScroll<HTMLButtonElement>({ behavior: 'smooth' });
+
+  const [ref, scroll] = useScroll();
+  ref satisfies RefObject<HTMLElement | null>;
+  scroll satisfies {
+    intoView: (scrollIntoViewOptions?: ScrollIntoViewOptions) => void;
+    to: (scrollToOptions?: ScrollToOptions) => void;
+  };
+
+  scroll.intoView();
+  scroll.intoView(undefined);
+  scroll.intoView({ behavior: 'smooth' });
+  scroll.intoView({ behavior: 'instant', block: 'center', inline: 'end' });
+
+  scroll.to();
+  scroll.to(undefined);
+  scroll.to({ behavior: 'smooth' });
+  scroll.to({ behavior: 'instant', left: 10, top: 20 });
+
+  const [divRef, divScroll] = useScroll<HTMLDivElement>();
+  divRef satisfies RefObject<HTMLDivElement | null>;
+  divScroll satisfies {
+    intoView: (scrollIntoViewOptions?: ScrollIntoViewOptions) => void;
+    to: (scrollToOptions?: ScrollToOptions) => void;
+  };
+
+  // @ts-expect-error - `behavior` should be a valid scroll behavior.
+  useScroll({ behavior: 'fast' });
+  // @ts-expect-error - `useScroll` accepts only one argument.
+  useScroll({}, {});
+  // @ts-expect-error - The ref target should be an `HTMLElement`.
+  useScroll<SVGElement>();
+  // @ts-expect-error - `intoView` options should match `ScrollIntoViewOptions`.
+  scroll.intoView({ top: 10 });
+  // @ts-expect-error - `to` options should match `ScrollToOptions`.
+  scroll.to({ block: 'center' });
+}
+
+// #endregion useScroll
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-scroll.ts
+++ b/packages/react-kit/src/hooks/use-scroll.ts
@@ -2,79 +2,13 @@
  * @fileoverview `useScroll` hook.
  */
 
+/* global ScrollOptions:readonly, ScrollIntoViewOptions:readonly, ScrollToOptions:readonly */
+
 // --------------------------------------------------------------------------------
 // Import
 // --------------------------------------------------------------------------------
 
 import { useCallback, useMemo, useRef, type RefObject } from 'react';
-
-// --------------------------------------------------------------------------------
-// Typedef
-// --------------------------------------------------------------------------------
-
-/**
- * Controls how scrolling is performed.
- *
- * - `'auto'` uses the computed CSS `scroll-behavior` value.
- * - `'instant'` jumps to the target position instantly.
- * - `'smooth'` animates to the target position.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#behavior
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo#behavior
- */
-type ScrollBehavior = 'auto' | 'instant' | 'smooth';
-
-/**
- * Alignment position used by `scrollIntoView()`.
- *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block
- */
-type ScrollLogicalPosition = 'center' | 'end' | 'nearest' | 'start';
-
-/**
- * Common options shared by scroll methods.
- */
-interface ScrollOptions {
-  /**
-   * Scrolling behavior to use when moving to a target.
-   * @default 'auto'
-   */
-  behavior?: ScrollBehavior;
-}
-
-/**
- * Options passed to `Element.scrollIntoView()`.
- */
-interface ScrollIntoViewOptions extends ScrollOptions {
-  /**
-   * Vertical alignment of the target element within the scrollable ancestor.
-   * @default 'start'
-   */
-  block?: ScrollLogicalPosition;
-
-  /**
-   * Horizontal alignment of the target element within the scrollable ancestor.
-   * @default 'nearest'
-   */
-  inline?: ScrollLogicalPosition;
-}
-
-/**
- * Options passed to `Window.scrollTo()`.
- */
-interface ScrollToOptions extends ScrollOptions {
-  /**
-   * Horizontal document coordinate, in pixels, to scroll to.
-   * @default undefined
-   */
-  left?: number;
-
-  /**
-   * Vertical document coordinate, in pixels, to scroll to.
-   * @default undefined
-   */
-  top?: number;
-}
 
 // --------------------------------------------------------------------------------
 // Export
@@ -109,7 +43,7 @@ interface ScrollToOptions extends ScrollOptions {
  * }
  * ```
  */
-export function useScroll<T extends HTMLElement>({
+export function useScroll<T extends HTMLElement = HTMLElement>({
   behavior = 'auto',
 }: ScrollOptions = {}): readonly [
   ref: RefObject<T | null>,


### PR DESCRIPTION
This pull request improves the type safety and maintainability of the `useScroll` hook in the `react-kit` package. The main changes include removing local type definitions in favor of using global DOM types, and adding a comprehensive type test file to ensure correct usage and type safety for the `useScroll` hook.

**Type System Improvements:**

* Removed local type definitions for `ScrollBehavior`, `ScrollLogicalPosition`, `ScrollOptions`, `ScrollIntoViewOptions`, and `ScrollToOptions` in `use-scroll.ts`, and replaced them with global DOM types to reduce redundancy and ensure consistency with browser APIs.

* Updated the generic parameter in the `useScroll` hook to default to `HTMLElement`, improving usability and type inference for consumers of the hook.

**Testing Enhancements:**

* Added a new type test file `use-scroll.test-d.ts` to verify the type signatures and usage patterns of the `useScroll` hook, including both valid and invalid cases. This helps catch type errors early and documents expected usage.