### PR TITLE
ci(*): update `cron` schedule to run every Monday at 11:00 PM UTC

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,7 +2,7 @@ name: cron
 
 on:
   schedule:
-    - cron: '0 23 * * *' # Runs every day at 11:00 PM UTC
+    - cron: '0 23 * * 1' # Runs every Monday at 11:00 PM UTC
 
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request updates the schedule for the `cron` workflow to run weekly instead of daily.

Workflow schedule update:

* [`.github/workflows/cron.yml`](diffhunk://#diff-69b9772a7fe51bd7c367926862d89ca7d8949cc9832b3645e610a1ec5bfa1ddfL5-R5): Changed the cron schedule to run every Monday at 11:00 PM UTC instead of every day at that time.