### PR TITLE
feat(@lumir/utils): add generic frontmatter data types

### DIFF
--- a/packages/utils/src/frontmatter.test-d.ts
+++ b/packages/utils/src/frontmatter.test-d.ts
@@ -36,6 +36,7 @@ frontmatter('');
 frontmatter('---\ntitle: Title\n---\nHello, world!');
 frontmatter('').content satisfies string;
 frontmatter('').data satisfies unknown;
+frontmatter<{ title: string }>('').data satisfies { title: string } | null;
 
 // @ts-expect-error - `frontmatter` requires input.
 frontmatter();
@@ -43,6 +44,10 @@ frontmatter();
 frontmatter(123);
 // @ts-expect-error - `data` is unknown and should be narrowed before use.
 frontmatter('').data satisfies string;
+// @ts-expect-error - Typed `data` can be null when front matter is not found.
+frontmatter<{ title: string }>('').data satisfies { title: string };
+// @ts-expect-error - Typed `data` should match the specified data type.
+frontmatter<{ title: string }>('').data satisfies { author: string } | null;
 
 // #endregion frontmatter
 // --------------------------------------------------------------------------------
@@ -69,6 +74,7 @@ frontmatter('').data satisfies string;
 frontmatterData('');
 frontmatterData('---\ntitle: Title\n---\nHello, world!');
 frontmatterData('').data satisfies unknown;
+frontmatterData<{ title: string }>('').data satisfies { title: string } | null;
 
 // @ts-expect-error - `frontmatterData` requires input.
 frontmatterData();
@@ -78,6 +84,10 @@ frontmatterData(123);
 frontmatterData('').content satisfies string;
 // @ts-expect-error - `data` is unknown and should be narrowed before use.
 frontmatterData('').data satisfies string;
+// @ts-expect-error - Typed `data` can be null when front matter is not found.
+frontmatterData<{ title: string }>('').data satisfies { title: string };
+// @ts-expect-error - Typed `data` should match the specified data type.
+frontmatterData<{ title: string }>('').data satisfies { author: string } | null;
 
 // #endregion frontmatterData
 // --------------------------------------------------------------------------------

--- a/packages/utils/src/frontmatter.ts
+++ b/packages/utils/src/frontmatter.ts
@@ -27,12 +27,15 @@ const frontmatterRegex =
 /**
  * Parses the front matter from a string and returns the content without the front matter and the parsed data.
  * If no front matter is found, it returns the original content and `null` data.
+ * @template Data The expected type of the parsed front matter data. Defaults to `unknown`.
  * @example
  *
  * ```ts
  * import { frontmatter } from '@lumir/utils';
  *
- * const result = frontmatter(`---\ntitle: Title\nauthor: Author\n---\nHello, world!`);
+ * type Data = { title: string; author: string };
+ *
+ * const result = frontmatter<Data>(`---\ntitle: Title\nauthor: Author\n---\nHello, world!`);
  *
  * console.log(result);
  * // {
@@ -44,9 +47,11 @@ const frontmatterRegex =
  * // }
  * ```
  */
-export function frontmatter(input: string): {
+export function frontmatter<Data = unknown>(
+  input: string,
+): {
   content: string;
-  data: unknown;
+  data: Data | null;
 } {
   const match = input.match(frontmatterRegex);
 
@@ -66,12 +71,15 @@ export function frontmatter(input: string): {
 /**
  * Parses the front matter from a string and returns only the parsed data.
  * If no front matter is found, it returns `null` data.
+ * @template Data The expected type of the parsed front matter data. Defaults to `unknown`.
  * @example
  *
  * ```ts
  * import { frontmatterData } from '@lumir/utils';
  *
- * const result = frontmatterData(`---\ntitle: Title\nauthor: Author\n---\nHello, world!`);
+ * type Data = { title: string; author: string };
+ *
+ * const result = frontmatterData<Data>(`---\ntitle: Title\nauthor: Author\n---\nHello, world!`);
  *
  * console.log(result);
  * // {
@@ -82,7 +90,11 @@ export function frontmatter(input: string): {
  * // }
  * ```
  */
-export function frontmatterData(input: string): { data: unknown } {
+export function frontmatterData<Data = unknown>(
+  input: string,
+): {
+  data: Data | null;
+} {
   const match = input.match(frontmatterRegex);
 
   if (!match) {


### PR DESCRIPTION
This pull request improves the type safety and flexibility of the `frontmatter` and `frontmatterData` utility functions by introducing generic type parameters. It also updates their test cases to validate the new behavior and error handling.

### Type system improvements

* Updated `frontmatter` and `frontmatterData` in `frontmatter.ts` to accept an optional generic type parameter (`Data`), allowing callers to specify the expected type of the parsed front matter data. The return type for `data` is now `Data | null` instead of just `unknown`, improving type inference and safety. [[1]](diffhunk://#diff-ba4749bd4ca2ca84b95410bb683396cbfaaa4c35fdd02214fb045654daabaec9L47-R54) [[2]](diffhunk://#diff-ba4749bd4ca2ca84b95410bb683396cbfaaa4c35fdd02214fb045654daabaec9L85-R97)
* Updated JSDoc comments and examples to illustrate the use of the new generic parameter. [[1]](diffhunk://#diff-ba4749bd4ca2ca84b95410bb683396cbfaaa4c35fdd02214fb045654daabaec9R30-R38) [[2]](diffhunk://#diff-ba4749bd4ca2ca84b95410bb683396cbfaaa4c35fdd02214fb045654daabaec9R74-R82)

### Test updates

* Enhanced test cases in `frontmatter.test-d.ts` to check that the new generic parameter works as expected, including cases where `data` can be `null` or does not match the specified type. [[1]](diffhunk://#diff-413f973e14c397c34082233fd74740eda2745b6f8935c9ac3cf02a5510b7f9ebR39-R50) [[2]](diffhunk://#diff-413f973e14c397c34082233fd74740eda2745b6f8935c9ac3cf02a5510b7f9ebR77) [[3]](diffhunk://#diff-413f973e14c397c34082233fd74740eda2745b6f8935c9ac3cf02a5510b7f9ebR87-R90)