### PR TITLE
test(@lumir/react-kit): add type tests for `usePrevious` hook and refactor existing tests

### DIFF
--- a/packages/react-kit/src/hooks/use-previous.test-d.ts
+++ b/packages/react-kit/src/hooks/use-previous.test-d.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Type test for `use-previous.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { usePrevious } from './use-previous.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region usePrevious
+
+({}) as typeof usePrevious satisfies Function;
+({}) as typeof usePrevious satisfies <T>(value: T) => T;
+
+// @ts-expect-error - `usePrevious` should be a function.
+({}) as typeof usePrevious satisfies boolean;
+// @ts-expect-error - `usePrevious` should be a function.
+({}) as typeof usePrevious satisfies string;
+
+function usePreviousTypeTest() {
+  const previousNumber = usePrevious(0);
+  const previousString = usePrevious('initial');
+  const previousObject = usePrevious({ value: true });
+  const previousUnion = usePrevious<number | string>(0);
+
+  previousNumber satisfies number;
+  previousString satisfies string;
+  previousObject satisfies { value: boolean };
+  previousUnion satisfies number | string;
+
+  // @ts-expect-error - The value should match the explicit generic type.
+  usePrevious<number>('0');
+  // @ts-expect-error - `usePrevious` requires a value.
+  usePrevious();
+  // @ts-expect-error - `usePrevious` accepts only one argument.
+  usePrevious(0, 1);
+}
+
+// #endregion usePrevious
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-previous.test.ts
+++ b/packages/react-kit/src/hooks/use-previous.test.ts
@@ -6,7 +6,7 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { assert, assertType, describe, it } from 'vitest';
+import { assert, describe, it } from 'vitest';
 import { renderHook } from 'vitest-browser-react';
 import { usePrevious } from './use-previous.js';
 
@@ -15,57 +15,42 @@ import { usePrevious } from './use-previous.js';
 // --------------------------------------------------------------------------------
 
 describe('use-previous', () => {
-  describe('unit', () => {
-    it('Initial value should be returned as given - 1', async () => {
-      const { result } = await renderHook(() => usePrevious(0));
-      const initialValue = result.current;
+  it('Initial value should be returned as given - 1', async () => {
+    const { result } = await renderHook(() => usePrevious(0));
+    const initialValue = result.current;
 
-      assert.strictEqual(initialValue, 0);
-    });
-
-    it('Initial value should be returned as given - 2', async () => {
-      const { result } = await renderHook(() => usePrevious('initial'));
-      const initialValue = result.current;
-
-      assert.strictEqual(initialValue, 'initial');
-    });
-
-    it('Previous value is returned when state changes', async () => {
-      let value: number | string = 0;
-      const { result, rerender } = await renderHook(() => usePrevious(value));
-
-      value = 1;
-      await rerender();
-      assert.strictEqual(result.current, 0);
-
-      value = 2;
-      await rerender();
-      assert.strictEqual(result.current, 1);
-
-      value = 3;
-      await rerender();
-      assert.strictEqual(result.current, 2);
-
-      value = 'hi';
-      await rerender();
-      assert.strictEqual(result.current, 3);
-
-      value = 'hello';
-      await rerender();
-      assert.strictEqual(result.current, 'hi');
-    });
+    assert.strictEqual(initialValue, 0);
   });
 
-  describe('type', () => {
-    it('`usePrevious` should be generic and maintain type consistency', () => {
-      assertType<(value: number) => number>(usePrevious<number>);
-      assertType<(value: string) => string>(usePrevious<string>);
-      assertType<(value: { a: number }) => { a: number }>(usePrevious<{ a: number }>);
+  it('Initial value should be returned as given - 2', async () => {
+    const { result } = await renderHook(() => usePrevious('initial'));
+    const initialValue = result.current;
 
-      // @ts-expect-error -- Type mismatch should be caught
-      assertType<(value: number) => string>(usePrevious<number>);
-      // @ts-expect-error -- Type mismatch should be caught
-      assertType<(value: string) => number>(usePrevious<string>);
-    });
+    assert.strictEqual(initialValue, 'initial');
+  });
+
+  it('Previous value is returned when state changes', async () => {
+    let value: number | string = 0;
+    const { result, rerender } = await renderHook(() => usePrevious(value));
+
+    value = 1;
+    await rerender();
+    assert.strictEqual(result.current, 0);
+
+    value = 2;
+    await rerender();
+    assert.strictEqual(result.current, 1);
+
+    value = 3;
+    await rerender();
+    assert.strictEqual(result.current, 2);
+
+    value = 'hi';
+    await rerender();
+    assert.strictEqual(result.current, 3);
+
+    value = 'hello';
+    await rerender();
+    assert.strictEqual(result.current, 'hi');
   });
 });


### PR DESCRIPTION
This pull request refactors the type tests for the `usePrevious` hook by moving them from the runtime test file to a new dedicated type test file. This helps separate runtime and type-level testing concerns, making the tests more maintainable and clear.

**Test Refactoring:**

* Moved all type-level tests for `usePrevious` from `use-previous.test.ts` to a new file `use-previous.test-d.ts`, ensuring type assertions and errors are checked separately from runtime behavior. [[1]](diffhunk://#diff-1fbbf083a479bd5fc3273506dc3b6737a50a225b8b86afd2f79921ebe41ada24R1-R46) [[2]](diffhunk://#diff-3b479eb4d563ca1292afbfdcfca486232f4b3166d10eec47bc817d5f47bfd277L58-L71)
* Removed the use of `assertType` and related type assertions from `use-previous.test.ts`, leaving only runtime tests in that file. [[1]](diffhunk://#diff-3b479eb4d563ca1292afbfdcfca486232f4b3166d10eec47bc817d5f47bfd277L9-R9) [[2]](diffhunk://#diff-3b479eb4d563ca1292afbfdcfca486232f4b3166d10eec47bc817d5f47bfd277L58-L71)

**Test Coverage:**

* Added comprehensive type tests in `use-previous.test-d.ts` to verify that `usePrevious` is generic, maintains type consistency, and enforces correct argument types at compile time.