### PR TITLE
feat(@lumir/react-kit): add `usePreviousDistinct` hook

### DIFF
--- a/packages/react-kit/src/hooks/index.test.ts
+++ b/packages/react-kit/src/hooks/index.test.ts
@@ -12,6 +12,7 @@ import {
   useCountdown,
   useIsomorphicLayoutEffect,
   usePrevious,
+  usePreviousDistinct,
   useScroll,
   useSpeechRecognition,
   useToggle,
@@ -42,6 +43,11 @@ describe('index', () => {
     it('`usePrevious` should be defined', () => {
       assert.isDefined(usePrevious);
       assert.strictEqual(typeof usePrevious, 'function');
+    });
+
+    it('`usePreviousDistinct` should be defined', () => {
+      assert.isDefined(usePreviousDistinct);
+      assert.strictEqual(typeof usePreviousDistinct, 'function');
     });
 
     it('`useScroll` should be defined', () => {

--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from './use-boolean-state.js';
 export * from './use-countdown.js';
 export * from './use-isomorphic-layout-effect.js';
 export * from './use-previous.js';
+export * from './use-previous-distinct.js';
 export * from './use-scroll.js';
 export * from './use-speech-recognition.js';
 export * from './use-toggle.js';

--- a/packages/react-kit/src/hooks/use-previous-distinct.test-d.ts
+++ b/packages/react-kit/src/hooks/use-previous-distinct.test-d.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Type test for `use-previous-distinct.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import {
+  usePreviousDistinct,
+  type UsePreviousDistinctOptions,
+} from './use-previous-distinct.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region UsePreviousDistinctOptions
+
+let options: UsePreviousDistinctOptions<number>;
+
+options = {};
+options = { compareFn: Object.is };
+options = {
+  compareFn: (prev, next) => {
+    prev satisfies number;
+    next satisfies number;
+    return prev === next;
+  },
+};
+
+// @ts-expect-error - `compareFn` parameters should match the value type.
+options = { compareFn: (prev: string, next: string) => prev === next };
+// @ts-expect-error - `compareFn` should return a boolean.
+options = { compareFn: (prev, next) => Number(prev === next) };
+// @ts-expect-error - `unknown` is not a valid property of `UsePreviousDistinctOptions`.
+options = { unknown: 'unknown' };
+
+// #endregion UsePreviousDistinctOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region usePreviousDistinct
+
+({}) as typeof usePreviousDistinct satisfies Function;
+({}) as typeof usePreviousDistinct satisfies <T>(
+  value: T,
+  options?: UsePreviousDistinctOptions<T>,
+) => T;
+
+// @ts-expect-error - `usePreviousDistinct` should be a function.
+({}) as typeof usePreviousDistinct satisfies boolean;
+// @ts-expect-error - `usePreviousDistinct` should be a function.
+({}) as typeof usePreviousDistinct satisfies string;
+
+function usePreviousDistinctTypeTest() {
+  const previousNumber = usePreviousDistinct(0);
+  const previousString = usePreviousDistinct('initial');
+  const previousObject = usePreviousDistinct({ value: true });
+  const previousUnion = usePreviousDistinct<number | string>(0);
+
+  previousNumber satisfies number;
+  previousString satisfies string;
+  previousObject satisfies { value: boolean };
+  previousUnion satisfies number | string;
+
+  usePreviousDistinct(0, undefined);
+  usePreviousDistinct(0, {});
+  usePreviousDistinct(0, { compareFn: Object.is });
+  usePreviousDistinct(0, {
+    compareFn: (prev, next) => {
+      prev satisfies number;
+      next satisfies number;
+      return prev === next;
+    },
+  });
+
+  // @ts-expect-error - The value should match the explicit generic type.
+  usePreviousDistinct<number>('0');
+  // @ts-expect-error - `compareFn` parameters should match the value type.
+  usePreviousDistinct(0, { compareFn: (prev: string, next: string) => prev === next });
+  // @ts-expect-error - `compareFn` should return a boolean.
+  usePreviousDistinct(0, { compareFn: (prev, next) => Number(prev === next) });
+  // @ts-expect-error - `unknown` is not a valid option.
+  usePreviousDistinct(0, { unknown: 'unknown' });
+  // @ts-expect-error - `usePreviousDistinct` requires a value.
+  usePreviousDistinct();
+  // @ts-expect-error - `usePreviousDistinct` accepts only two arguments.
+  usePreviousDistinct(0, {}, {});
+}
+
+// #endregion usePreviousDistinct
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-previous-distinct.test.ts
+++ b/packages/react-kit/src/hooks/use-previous-distinct.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Test for `use-previous-distinct.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { assert, describe, it } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { usePreviousDistinct } from './use-previous-distinct.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('use-previous-distinct', () => {
+  it('Initial value should be returned as given - 1', async () => {
+    const { result } = await renderHook(() => usePreviousDistinct(0));
+    const initialValue = result.current;
+
+    assert.strictEqual(initialValue, 0);
+  });
+
+  it('Initial value should be returned as given - 2', async () => {
+    const { result } = await renderHook(() => usePreviousDistinct('initial'));
+    const initialValue = result.current;
+
+    assert.strictEqual(initialValue, 'initial');
+  });
+
+  it('Previous value is returned when state changes', async () => {
+    let value: number | string = 0;
+    const { result, rerender } = await renderHook(() => usePreviousDistinct(value));
+
+    value = 1;
+    await rerender();
+    assert.strictEqual(result.current, 0);
+
+    value = 2;
+    await rerender();
+    assert.strictEqual(result.current, 1);
+
+    value = 3;
+    await rerender();
+    assert.strictEqual(result.current, 2);
+
+    value = 'hi';
+    await rerender();
+    assert.strictEqual(result.current, 3);
+
+    value = 'hello';
+    await rerender();
+    assert.strictEqual(result.current, 'hi');
+  });
+
+  it('Previous distinct value is preserved when the current value does not change', async () => {
+    // Unlike `usePrevious`, `usePreviousDistinct` should keep returning the previous
+    // distinct value when the immediately preceding render matches the current value.
+    let value = 0;
+    const { result, rerender } = await renderHook(() => usePreviousDistinct(value));
+
+    value = 1;
+    await rerender();
+    assert.strictEqual(result.current, 0);
+
+    await rerender();
+    assert.strictEqual(result.current, 0);
+
+    value = 2;
+    await rerender();
+    assert.strictEqual(result.current, 1);
+
+    await rerender();
+    assert.strictEqual(result.current, 1);
+  });
+
+  it('Default `Object.is` comparison should treat separate object references as distinct values', async () => {
+    const initialValue = { id: 1 };
+    const structurallyEqualValue = { id: 1 };
+
+    let value = initialValue;
+    const { result, rerender } = await renderHook(() => usePreviousDistinct(value));
+
+    value = structurallyEqualValue;
+    await rerender();
+    assert.strictEqual(result.current, initialValue);
+
+    value = { id: 2 };
+    await rerender();
+    assert.strictEqual(result.current, structurallyEqualValue);
+  });
+
+  it('Custom `compareFn` should determine whether values are distinct', async () => {
+    const initialValue = { id: 1, label: 'initial' };
+    const equivalentValue = { id: 1, label: 'updated' };
+    const distinctValue = { id: 2, label: 'distinct' };
+
+    let value = initialValue;
+    const { result, rerender } = await renderHook(() =>
+      usePreviousDistinct(value, {
+        compareFn: (prev, next) => prev.id === next.id,
+      }),
+    );
+
+    value = equivalentValue;
+    await rerender();
+    assert.strictEqual(result.current, initialValue);
+
+    value = distinctValue;
+    await rerender();
+    assert.strictEqual(result.current, initialValue);
+
+    value = { id: 3, label: 'next distinct' };
+    await rerender();
+    assert.strictEqual(result.current, distinctValue);
+  });
+});

--- a/packages/react-kit/src/hooks/use-previous-distinct.ts
+++ b/packages/react-kit/src/hooks/use-previous-distinct.ts
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview `usePreviousDistinct` hook.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useEffect, useRef } from 'react';
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Options for the `usePreviousDistinct` hook.
+ */
+export interface UsePreviousDistinctOptions<T> {
+  /**
+   * An optional comparison function that determines whether two values are equivalent.
+   * @param prev The most recently tracked distinct value.
+   * @param next The current input value.
+   * @returns `true` if the values are considered equal, `false` otherwise.
+   * @default Object.is
+   */
+  compareFn?: (prev: T, next: T) => boolean;
+}
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * `usePreviousDistinct` is a React hook that returns the value preceding the
+ * current distinct value. It preserves the previous distinct value while the
+ * input is considered equivalent to the most recently tracked value.
+ * A `compareFn` function can be provided when values require custom equality
+ * semantics. By default, values are compared using `Object.is`.
+ *
+ * @param value The current value to track.
+ * @template T The type of the value.
+ * @returns The previous distinct value, or the current value on the initial render.
+ * @example
+ * ```tsx
+ * import { usePreviousDistinct } from '@lumir/react-kit/hooks';
+ *
+ * function Component({ count }: { count: number }) {
+ *   const previousCount = usePreviousDistinct(count);
+ *   // Your component logic here...
+ * }
+ * ```
+ */
+export function usePreviousDistinct<T>(
+  value: T,
+  { compareFn = Object.is }: UsePreviousDistinctOptions<T> = {},
+): T {
+  // Without `'use no memo'`, React Compiler throws when `panicThreshold` is not `'none'`
+  // because this hook intentionally reads `ref.current` during render.
+  'use no memo';
+
+  const previousValueRef = useRef<T>(value);
+  const currentValueRef = useRef<T>(value);
+
+  useEffect(() => {
+    if (!compareFn(currentValueRef.current, value)) {
+      previousValueRef.current = currentValueRef.current;
+      currentValueRef.current = value;
+    }
+  }, [value, compareFn]);
+
+  // eslint-disable-next-line react-hooks/refs -- Intentionally reads the value captured before this render's effect.
+  return compareFn(currentValueRef.current, value)
+    ? previousValueRef.current
+    : currentValueRef.current;
+}

--- a/packages/react-kit/src/hooks/use-previous-distinct.ts
+++ b/packages/react-kit/src/hooks/use-previous-distinct.ts
@@ -38,6 +38,7 @@ export interface UsePreviousDistinctOptions<T> {
  * semantics. By default, values are compared using `Object.is`.
  *
  * @param value The current value to track.
+ * @param options Options containing the optional `compareFn`, which defaults to `Object.is`.
  * @template T The type of the value.
  * @returns The previous distinct value, or the current value on the initial render.
  * @example

--- a/packages/react-kit/src/hooks/use-previous.test.ts
+++ b/packages/react-kit/src/hooks/use-previous.test.ts
@@ -53,4 +53,25 @@ describe('use-previous', () => {
     await rerender();
     assert.strictEqual(result.current, 'hi');
   });
+
+  it('Previous value is updated when the current value does not change', async () => {
+    // Unlike `usePreviousDistinct`, `usePrevious` should return the value
+    // from the immediately preceding render, even when it matches the current value.
+    let value = 0;
+    const { result, rerender } = await renderHook(() => usePrevious(value));
+
+    value = 1;
+    await rerender();
+    assert.strictEqual(result.current, 0);
+
+    await rerender();
+    assert.strictEqual(result.current, 1);
+
+    value = 2;
+    await rerender();
+    assert.strictEqual(result.current, 1);
+
+    await rerender();
+    assert.strictEqual(result.current, 2);
+  });
 });

--- a/packages/react-kit/src/hooks/use-previous.ts
+++ b/packages/react-kit/src/hooks/use-previous.ts
@@ -13,11 +13,11 @@ import { useEffect, useRef } from 'react';
 // --------------------------------------------------------------------------------
 
 /**
- * `usePrevious` hook to get the previous value of a state or prop.
+ * `usePrevious` is a React hook that returns the value from the immediately preceding render.
  *
  * @param value The current value to track.
  * @template T The type of the value.
- * @returns The previous value before the current render.
+ * @returns The value from the immediately preceding render, or the current value on the initial render.
  * @example
  * ```tsx
  * import { usePrevious } from '@lumir/react-kit/hooks';
@@ -39,6 +39,6 @@ export function usePrevious<T>(value: T): T {
     ref.current = value;
   }, [value]);
 
-  // eslint-disable-next-line react-hooks/refs -- `usePrevious` intentionally reads the value captured before this render's effect.
+  // eslint-disable-next-line react-hooks/refs -- Intentionally reads the value captured before this render's effect.
   return ref.current;
 }

--- a/packages/react-kit/vitest.config.js
+++ b/packages/react-kit/vitest.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     browser: {
       enabled: true,
+      headless: true,
       provider: playwright(),
       instances: [{ browser: 'chromium' }],
     },


### PR DESCRIPTION
This pull request introduces a new React hook `usePreviousDistinct` to the `react-kit` package, which tracks the previous distinct value of a state or prop, with optional custom comparison logic. It also adds comprehensive tests and type tests for the new hook, updates the main hooks index to export it, and clarifies the documentation for the existing `usePrevious` hook. Additionally, it tweaks the Vitest configuration for browser tests.

**New Hook and Exports:**

* Added the `usePreviousDistinct` hook in `use-previous-distinct.ts`, which returns the previous distinct value based on a customizable comparison function (defaults to `Object.is`). Includes full JSDoc and example usage.
* Exported `usePreviousDistinct` from the main hooks index (`index.ts`) and included it in the test imports to ensure it's available for consumers. [[1]](diffhunk://#diff-f4432a733b5ee38515910032e2d4ee426fe5afaec1370104c68acb446d885706R5) [[2]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR15)

**Testing:**

* Added a full test suite for `usePreviousDistinct` (`use-previous-distinct.test.ts`), covering default and custom comparison logic, and behavior differences from `usePrevious`.
* Added a type-level test file (`use-previous-distinct.test-d.ts`) to validate TypeScript typings and options for the new hook.
* Updated the hooks index test (`index.test.ts`) to assert that `usePreviousDistinct` is defined and is a function.

**Enhancements to Existing Hooks:**

* Improved the documentation for `usePrevious` to clarify that it returns the value from the immediately preceding render, and added a test to demonstrate its behavior versus `usePreviousDistinct`. [[1]](diffhunk://#diff-c32fef6ff6cdaae33f55ec8bf662c255a42b63708c63ebd332d3c02ece81388cL16-R20) [[2]](diffhunk://#diff-c32fef6ff6cdaae33f55ec8bf662c255a42b63708c63ebd332d3c02ece81388cL42-R42) [[3]](diffhunk://#diff-3b479eb4d563ca1292afbfdcfca486232f4b3166d10eec47bc817d5f47bfd277R56-R76)

**Test Configuration:**

* Enabled headless mode for browser tests in the Vitest configuration for more reliable CI runs.