### PR TITLE
refactor(moing): use context API and simplification

### DIFF
--- a/apps/moing/src/app.css
+++ b/apps/moing/src/app.css
@@ -1,32 +1,30 @@
 html,
-body {
-  width: 100%;
+body,
+#app {
   height: 100%;
-  line-height: 1;
 }
 
 #app {
   display: grid;
   grid-template-rows: var(--grid-height) 1fr var(--grid-height);
   grid-template-columns: var(--grid-width) 1fr var(--grid-width);
-  width: 100%;
-  height: 100%;
+  line-height: 1;
   color: var(--color-primary-white);
   background: var(--color-background) 0 / 15px 20px;
 
-  & > .config-button {
+  & > .config {
     grid-area: 1 / 1 / 2 / 2;
   }
 
-  & > .speech-button {
+  & > .speech {
     grid-area: 1 / 3 / 2 / 4;
   }
 
-  & > .reload-button {
+  & > .reload {
     grid-area: 3 / 1 / 4 / 2;
   }
 
-  & > .submit-button {
+  & > .submit {
     grid-area: 3 / 3 / 4 / 4;
   }
 

--- a/apps/moing/src/app.tsx
+++ b/apps/moing/src/app.tsx
@@ -24,8 +24,8 @@ import Server from '@/components/server';
 import Timer from '@/components/timer';
 import Title from '@/components/title';
 import { useConfigContext } from '@/contexts/config-context';
+import { useInterviewContext } from '@/contexts/interview-context';
 import { useScenarioContext } from '@/contexts/scenario-context';
-import useInterview from '@/hooks/use-interview';
 
 import './app.css';
 
@@ -35,11 +35,11 @@ import './app.css';
 
 export default function App() {
   const { config, updateConfig } = useConfigContext();
+  const { listening, submit, toggleListening } = useInterviewContext();
   const { section } = useScenarioContext();
-  const interview = useInterview<HTMLDivElement>();
   const initialCount = config.time * 60 * 1_000;
   const [currentCount, setCurrentCount] = useCountdown(initialCount, {
-    onComplete: interview.submit,
+    onComplete: submit,
   });
   const [scrollRef, scroll] = useScroll<HTMLDivElement>({ behavior: 'smooth' });
 
@@ -63,9 +63,9 @@ export default function App() {
       <Button
         type="speech"
         icon={<CiMicrophoneOn size="40px" />}
-        hoverEffect={interview.listening}
+        hoverEffect={listening}
         onClick={() => {
-          interview.toggleListening();
+          toggleListening();
         }}
       />
       <Button
@@ -79,7 +79,7 @@ export default function App() {
         type="submit"
         icon={<IoIosCheckmarkCircleOutline size="39px" />}
         onClick={() => {
-          interview.submit();
+          submit();
           setCurrentCount(0);
         }}
       />
@@ -90,14 +90,13 @@ export default function App() {
         <div ref={scrollRef}>
           <Title />
           <Server
-            interview={interview}
             onTestWriteComplete={() => {
               setCurrentCount(initialCount);
             }}
           />
-          <Client interview={interview} />
+          <Client />
           <Config />
-          <MainButton interview={interview} />
+          <MainButton />
         </div>
       </main>
     </>

--- a/apps/moing/src/components/button.tsx
+++ b/apps/moing/src/components/button.tsx
@@ -40,7 +40,7 @@ export default function Button({ type, icon, onClick, hoverEffect = false }: Pro
   return (
     <div
       className={cn(
-        `${type}-button`,
+        `${type}`,
         'custom-flex-center',
         'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',

--- a/apps/moing/src/components/client.tsx
+++ b/apps/moing/src/components/client.tsx
@@ -9,27 +9,19 @@
 import { cn } from '@lumir/utils';
 
 import NeonDiv from '@/components/neon-div';
+import { useInterviewContext } from '@/contexts/interview-context';
 import { useScenarioContext } from '@/contexts/scenario-context';
-import useInterview from '@/hooks/use-interview';
 
 import styles from './client.module.css';
-
-// --------------------------------------------------------------------------------
-// Typedef
-// --------------------------------------------------------------------------------
-
-interface Props {
-  interview: ReturnType<typeof useInterview<HTMLDivElement>>;
-}
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
-export default function Client({ interview }: Props) {
+export default function Client() {
+  const { contentRef } = useInterviewContext();
   const { section } = useScenarioContext();
   const { status } = section.client;
-  const { contentRef } = interview;
 
   return (
     <NeonDiv

--- a/apps/moing/src/components/main-button.module.css
+++ b/apps/moing/src/components/main-button.module.css
@@ -5,10 +5,7 @@
 }
 
 @keyframes pointer-events-none {
-  from {
-    pointer-events: none;
-  }
-
+  from,
   to {
     pointer-events: none;
   }

--- a/apps/moing/src/components/main-button.tsx
+++ b/apps/moing/src/components/main-button.tsx
@@ -12,28 +12,20 @@ import { cn } from '@lumir/utils';
 import NeonButton from '@/components/neon-button';
 import NeonFont from '@/components/neon-font';
 import { useConfigContext } from '@/contexts/config-context';
+import { useInterviewContext } from '@/contexts/interview-context';
 import { useScenarioContext } from '@/contexts/scenario-context';
-import useInterview from '@/hooks/use-interview';
 
 import styles from './main-button.module.css';
-
-// --------------------------------------------------------------------------------
-// Typedef
-// --------------------------------------------------------------------------------
-
-interface Props {
-  interview: ReturnType<typeof useInterview>;
-}
 
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
-export default function ButtonMain({ interview }: Props) {
+export default function ButtonMain() {
   const { config, updateConfig, isConfigDone } = useConfigContext();
+  const { initInterview } = useInterviewContext();
   const { section, toNextSection, toLastSection, isLastSection } = useScenarioContext();
   const { content, status } = section['main-button'];
-  const { initInterview } = interview;
 
   const onClick: MouseEventHandler<HTMLButtonElement> = e => {
     if (content === 'PRESS') {

--- a/apps/moing/src/components/neon-button.module.css
+++ b/apps/moing/src/components/neon-button.module.css
@@ -75,10 +75,6 @@
 }
 
 @keyframes btn-anim1 {
-  0% {
-    left: -100%;
-  }
-
   50%,
   100% {
     left: 100%;
@@ -86,10 +82,6 @@
 }
 
 @keyframes btn-anim2 {
-  0% {
-    top: -100%;
-  }
-
   50%,
   100% {
     top: 100%;
@@ -97,10 +89,6 @@
 }
 
 @keyframes btn-anim3 {
-  0% {
-    right: -100%;
-  }
-
   50%,
   100% {
     right: 100%;
@@ -108,10 +96,6 @@
 }
 
 @keyframes btn-anim4 {
-  0% {
-    bottom: -100%;
-  }
-
   50%,
   100% {
     bottom: 100%;

--- a/apps/moing/src/components/server.tsx
+++ b/apps/moing/src/components/server.tsx
@@ -13,8 +13,8 @@ import { cn } from '@lumir/utils';
 
 import NeonDiv from '@/components/neon-div';
 import { useConfigContext } from '@/contexts/config-context';
+import { useInterviewContext } from '@/contexts/interview-context';
 import { useScenarioContext } from '@/contexts/scenario-context';
-import useInterview from '@/hooks/use-interview';
 
 import styles from './server.module.css';
 
@@ -23,7 +23,6 @@ import styles from './server.module.css';
 // --------------------------------------------------------------------------------
 
 interface ServerProps {
-  interview: ReturnType<typeof useInterview>;
   onTestWriteComplete: () => void;
 }
 
@@ -52,11 +51,12 @@ function formatContent(content: string) {
 // Export
 // --------------------------------------------------------------------------------
 
-export default function Server({ interview, onTestWriteComplete }: ServerProps) {
+export default function Server({ onTestWriteComplete }: ServerProps) {
   const { config } = useConfigContext();
+  const { question, getInterviewInfo, isInterviewDone, getInterviewHistory } =
+    useInterviewContext();
   const { section, toNextSection } = useScenarioContext();
   const { content, mode, status } = section.server;
-  const { question, getInterviewInfo, isInterviewDone, getInterviewHistory } = interview;
   const [scrollRef, scroll] = useScroll<HTMLDivElement>({ behavior: 'smooth' });
   const text = useMemo(() => {
     if (mode === 'test') {

--- a/apps/moing/src/contexts/interview-context.tsx
+++ b/apps/moing/src/contexts/interview-context.tsx
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview interview-context.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { createContext, useContext, type PropsWithChildren } from 'react';
+
+import useInterview from '@/hooks/use-interview';
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Defines the interview state and actions provided by the `InterviewContext`.
+ */
+export type InterviewContextValue = ReturnType<typeof useInterview<HTMLDivElement>>;
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const InterviewContext = createContext<InterviewContextValue | undefined>(undefined);
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Returns the current interview state and actions.
+ *
+ * @returns The current interview state and actions.
+ * @throws {Error} Throws when called outside of `InterviewProvider`.
+ */
+export function useInterviewContext(): InterviewContextValue {
+  const context = useContext(InterviewContext);
+
+  if (!context) {
+    throw new Error('`useInterviewContext` must be used within an `InterviewProvider`.');
+  }
+
+  return context;
+}
+
+/**
+ * Provides interview state and actions to descendants.
+ *
+ * @param props The component props.
+ * @param props.children The child elements that should receive interview state.
+ * @returns A context provider wrapping the given children.
+ */
+export function InterviewProvider({ children }: PropsWithChildren) {
+  const interview = useInterview<HTMLDivElement>();
+
+  return <InterviewContext value={interview}>{children}</InterviewContext>;
+}

--- a/apps/moing/src/index.tsx
+++ b/apps/moing/src/index.tsx
@@ -10,6 +10,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ConfigProvider } from '@/contexts/config-context';
+import { InterviewProvider } from '@/contexts/interview-context';
 import { ScenarioProvider } from '@/contexts/scenario-context';
 
 import App from './app';
@@ -23,9 +24,11 @@ import '@/styles/index.css';
 createRoot(document.getElementById('app') as HTMLDivElement).render(
   <StrictMode>
     <ConfigProvider>
-      <ScenarioProvider>
-        <App />
-      </ScenarioProvider>
+      <InterviewProvider>
+        <ScenarioProvider>
+          <App />
+        </ScenarioProvider>
+      </InterviewProvider>
     </ConfigProvider>
   </StrictMode>,
 );

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,7 +5,7 @@ export default {
   languageOptions: {
     syntax: {
       types: {
-        // NOTE: `global()` is CSS Modules specific syntax
+        // NOTE: `global()` is a CSS Modules specific syntax
         'keyframes-name': '| <global()>',
         'global()': 'global( <custom-ident> )',
       },

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -13,6 +13,7 @@ export default {
   },
   rules: {
     'import-notation': 'string',
+    'property-no-unknown': [true, { ignoreProperties: ['composes'] }],
     // Enforce specific media feature breakpoints for consistency
     'media-feature-range-notation': 'context',
     'media-feature-name-allowed-list': ['width'],

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,7 +5,7 @@ export default {
   languageOptions: {
     syntax: {
       types: {
-        /* NOTE: `global()` is CSS Modules specific syntax */
+        // NOTE: `global()` is CSS Modules specific syntax
         'keyframes-name': '| <global()>',
         'global()': 'global( <custom-ident> )',
       },
@@ -13,7 +13,13 @@ export default {
   },
   rules: {
     'import-notation': 'string',
-    'property-no-unknown': [true, { ignoreProperties: ['composes'] }],
+    'property-no-unknown': [
+      true,
+      {
+        // NOTE: `composes` is a CSS Modules specific property
+        ignoreProperties: ['composes'],
+      },
+    ],
     // Enforce specific media feature breakpoints for consistency
     'media-feature-range-notation': 'context',
     'media-feature-name-allowed-list': ['width'],


### PR DESCRIPTION
This pull request refactors the interview state management in the application by introducing a new `InterviewContext` and `InterviewProvider`. It removes prop drilling of the interview logic and instead provides interview state and actions via React context, simplifying component interfaces and improving maintainability. Additionally, several CSS and minor code cleanups are included.

**Context Refactoring and State Management:**

* Introduced a new `InterviewContext` and `InterviewProvider` in `interview-context.tsx`, centralizing interview state and actions using React context instead of passing them as props. (`apps/moing/src/contexts/interview-context.tsx`, [apps/moing/src/contexts/interview-context.tsxR1-R59](diffhunk://#diff-e413e3b1bcb03a4ec5138b6281926c08b523bfdea4d2e034134cf88d78c9585aR1-R59))
* Updated `App`, `Client`, `Server`, and `MainButton` components to consume interview state using `useInterviewContext` instead of receiving `interview` as a prop. (`apps/moing/src/app.tsx`, [[1]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbR27-L28) [[2]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbR38-R42) [[3]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbL66-R68) [[4]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbL82-R82) [[5]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbL93-R99); `apps/moing/src/components/client.tsx`, [[6]](diffhunk://#diff-1a9a5213c4217a3b65da476ac856b20b5fb5e07030b44d967759380a57507bd3R12-L32); `apps/moing/src/components/server.tsx`, [[7]](diffhunk://#diff-41c1cd58a532fe061a794859eb646a71407e7f69f21ca71b7f8298b6cb691e3aR16-L17) [[8]](diffhunk://#diff-41c1cd58a532fe061a794859eb646a71407e7f69f21ca71b7f8298b6cb691e3aL26) [[9]](diffhunk://#diff-41c1cd58a532fe061a794859eb646a71407e7f69f21ca71b7f8298b6cb691e3aL55-L59); `apps/moing/src/components/main-button.tsx`, [[10]](diffhunk://#diff-8873f66b1b50d3c3aa9f8d7cb1402f3cf15694abcc84a54b70b101ac100a9ec4R15-L36)
* Wrapped the application in `InterviewProvider` in `index.tsx` to supply interview context throughout the component tree. (`apps/moing/src/index.tsx`, [[1]](diffhunk://#diff-7e4bd04a9abd184e3463e917dbaf15b709213aeaca936c7662eb02b324e8f4d7R13) [[2]](diffhunk://#diff-7e4bd04a9abd184e3463e917dbaf15b709213aeaca936c7662eb02b324e8f4d7R27-R31)

**Component and CSS Cleanups:**

* Updated button and grid class names for consistency, removing redundant suffixes and aligning with new context-based structure. (`apps/moing/src/app.css`, [[1]](diffhunk://#diff-e52ef24b2454017390bc3363d17ed4eda372918660a955d7b92f7a50c9947d4eL2-R27); `apps/moing/src/components/button.tsx`, [[2]](diffhunk://#diff-92f7eb504e321c09279d1fa0bb759ea09a5f57ddbbcaa8710ca7a6f17cbb670eL43-R43)
* Removed unnecessary animation keyframe definitions and cleaned up CSS modules. (`apps/moing/src/components/main-button.module.css`, [[1]](diffhunk://#diff-7c6609bd9f958b3dfef59a8eae680f82641d0c49d7f1c4f25a5b52c59293b4ceL8-R8); `apps/moing/src/components/neon-button.module.css`, [[2]](diffhunk://#diff-e3dcf4d7d419eae9a64f4e5fde6651742c36806648299f620e0b06a41adebb60L78-L114)

**Tooling and Linting:**

* Improved Stylelint configuration to better support CSS Modules syntax and ignore specific properties. (`stylelint.config.js`, [stylelint.config.jsL8-R22](diffhunk://#diff-42bcb39c4e0bdf439333e2c0b2c9b18ac2d8cbcb57e7bebc4a919db8f7de6103L8-R22))