### PR TITLE
refactor(blog): use category key order for sidebar

### DIFF
--- a/apps/blog/src/components/aside/categories.tsx
+++ b/apps/blog/src/components/aside/categories.tsx
@@ -33,35 +33,33 @@ const markdownCollection = createMarkdownCollection();
 export default async function Categories({ lang }: PropsWithLang) {
   return (
     <ul className={styles.categories}>
-      {markdownCollection.nonEmptyCategoryKeys[lang]
-        .sort((a, b) => categoryMeta[a].order - categoryMeta[b].order) // Ascending.
-        .map(categoryKey => {
-          const {
-            name: { en, ko },
-            reactIcons,
-          } = categoryMeta[categoryKey];
+      {markdownCollection.nonEmptyCategoryKeys[lang].map(categoryKey => {
+        const {
+          name: { en, ko },
+          reactIcons,
+        } = categoryMeta[categoryKey];
 
-          return (
-            <li key={categoryKey}>
-              <Link
-                className="custom-hover-effect"
-                href={`/${lang}/categories/${categoryKey}`}
-              >
-                <div className={cn(styles['react-icons'], 'custom-flex-center')}>
-                  {reactIcons}
-                </div>
-                <div className={styles['name-en']}>{en}</div>
-                <div className={styles['name-ko']}>{ko}</div>
-                <div className={cn(styles['count-docs'], 'custom-flex-center')}>
-                  <span className="custom-flex-center">
-                    {markdownCollection.byLangCategory[lang][categoryKey].length}
-                  </span>
-                  <FaPen />
-                </div>
-              </Link>
-            </li>
-          );
-        })}
+        return (
+          <li key={categoryKey}>
+            <Link
+              className="custom-hover-effect"
+              href={`/${lang}/categories/${categoryKey}`}
+            >
+              <div className={cn(styles['react-icons'], 'custom-flex-center')}>
+                {reactIcons}
+              </div>
+              <div className={styles['name-en']}>{en}</div>
+              <div className={styles['name-ko']}>{ko}</div>
+              <div className={cn(styles['count-docs'], 'custom-flex-center')}>
+                <span className="custom-flex-center">
+                  {markdownCollection.byLangCategory[lang][categoryKey].length}
+                </span>
+                <FaPen />
+              </div>
+            </Link>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/apps/blog/src/data/category.tsx
+++ b/apps/blog/src/data/category.tsx
@@ -31,7 +31,7 @@ import {
   SiThealgorithms,
   TbBrandNextjs,
 } from '@lumir/react-kit/svgs';
-import { type MetaWithOrder } from './meta';
+import { type Meta } from './meta';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -48,6 +48,7 @@ export type CategoryKey = (typeof categoryKeys)[number];
 
 /**
  * Represents the keys of the category, which are used to identify each category in the `categoryMeta` object.
+ * - NOTE: The order here determines the sidebar order, so modify it with care.
  */
 export const categoryKeys = [
   'html',
@@ -77,7 +78,7 @@ export const categoryKeys = [
 
 /**
  * An object containing metadata for the category fields,
- * including their names in English and Korean, as well as associated React icons and their order.
+ * including their names in English and Korean, as well as associated React icons.
  */
 export const categoryMeta = {
   html: {
@@ -86,7 +87,6 @@ export const categoryMeta = {
       ko: '하이퍼 텍스트 마크업 언어',
     },
     reactIcons: <FaHtml5 />,
-    order: 1,
   },
   markdown: {
     name: {
@@ -94,7 +94,6 @@ export const categoryMeta = {
       ko: '마크다운',
     },
     reactIcons: <FaMarkdown />,
-    order: 2,
   },
   css: {
     name: {
@@ -102,7 +101,6 @@ export const categoryMeta = {
       ko: '캐스케이딩 스타일 시트',
     },
     reactIcons: <FaCss3Alt />,
-    order: 3,
   },
   cpp: {
     name: {
@@ -110,7 +108,6 @@ export const categoryMeta = {
       ko: 'C/C++',
     },
     reactIcons: <SiCplusplus />,
-    order: 4,
   },
   javascript: {
     name: {
@@ -118,7 +115,6 @@ export const categoryMeta = {
       ko: '자바스크립트',
     },
     reactIcons: <RiJavascriptFill />,
-    order: 5,
   },
   nodejs: {
     name: {
@@ -126,7 +122,6 @@ export const categoryMeta = {
       ko: '노드JS',
     },
     reactIcons: <FaNodeJs />,
-    order: 6,
   },
   npm: {
     name: {
@@ -134,7 +129,6 @@ export const categoryMeta = {
       ko: '노드JS 패키지 매니저',
     },
     reactIcons: <FaNpm />,
-    order: 7,
   },
   react: {
     name: {
@@ -142,7 +136,6 @@ export const categoryMeta = {
       ko: '리액트',
     },
     reactIcons: <FaReact />,
-    order: 8,
   },
   nextjs: {
     name: {
@@ -150,7 +143,6 @@ export const categoryMeta = {
       ko: '넥스트JS',
     },
     reactIcons: <TbBrandNextjs />,
-    order: 9,
   },
   linux: {
     name: {
@@ -158,7 +150,6 @@ export const categoryMeta = {
       ko: '리눅스',
     },
     reactIcons: <FaLinux />,
-    order: 10,
   },
   data: {
     name: {
@@ -166,7 +157,6 @@ export const categoryMeta = {
       ko: '데이터 포맷',
     },
     reactIcons: <MdDataObject />,
-    order: 11,
   },
   database: {
     name: {
@@ -174,7 +164,6 @@ export const categoryMeta = {
       ko: '데이터베이스',
     },
     reactIcons: <FaDatabase />,
-    order: 12,
   },
   git: {
     name: {
@@ -182,7 +171,6 @@ export const categoryMeta = {
       ko: '깃/깃허브',
     },
     reactIcons: <FaGithub />,
-    order: 13,
   },
   vscode: {
     name: {
@@ -190,7 +178,6 @@ export const categoryMeta = {
       ko: '비주얼 스튜디오 코드',
     },
     reactIcons: <BiLogoVisualStudio />,
-    order: 14,
   },
   openai: {
     name: {
@@ -198,7 +185,6 @@ export const categoryMeta = {
       ko: '오픈AI',
     },
     reactIcons: <SiOpenai />,
-    order: 15,
   },
   baekjoon: {
     name: {
@@ -206,7 +192,6 @@ export const categoryMeta = {
       ko: '백준',
     },
     reactIcons: <FaCode />,
-    order: 16,
   },
   programmers: {
     name: {
@@ -214,7 +199,6 @@ export const categoryMeta = {
       ko: '프로그래머스',
     },
     reactIcons: <GiHummingbird />,
-    order: 17,
   },
   algorithm: {
     name: {
@@ -222,7 +206,6 @@ export const categoryMeta = {
       ko: '알고리즘',
     },
     reactIcons: <SiThealgorithms />,
-    order: 18,
   },
   network: {
     name: {
@@ -230,7 +213,6 @@ export const categoryMeta = {
       ko: '네트워크',
     },
     reactIcons: <LuNetwork />,
-    order: 19,
   },
   convention: {
     name: {
@@ -238,7 +220,6 @@ export const categoryMeta = {
       ko: '코딩 컨벤션',
     },
     reactIcons: <FaScrewdriverWrench />,
-    order: 20,
   },
   cs: {
     name: {
@@ -246,7 +227,6 @@ export const categoryMeta = {
       ko: '컴퓨터 과학',
     },
     reactIcons: <FaLaptopCode />,
-    order: 21,
   },
   synology: {
     name: {
@@ -254,7 +234,6 @@ export const categoryMeta = {
       ko: '시놀로지 나스',
     },
     reactIcons: <SiSynology />,
-    order: 22,
   },
   essay: {
     name: {
@@ -262,6 +241,5 @@ export const categoryMeta = {
       ko: '에세이',
     },
     reactIcons: <FaBookOpen />,
-    order: 23,
   },
-} as const satisfies Record<CategoryKey, MetaWithOrder>;
+} as const satisfies Record<CategoryKey, Meta>;

--- a/apps/blog/src/data/meta.ts
+++ b/apps/blog/src/data/meta.ts
@@ -27,14 +27,3 @@ export interface Meta {
    */
   readonly reactIcons: JSX.Element;
 }
-
-/**
- * Represents shared metadata with an additional `order` property,
- * which can be used for sorting or displaying items in a specific sequence.
- */
-export interface MetaWithOrder extends Meta {
-  /**
-   * The order of the item, which can be used for sorting or displaying items in a specific sequence.
-   */
-  readonly order: number;
-}


### PR DESCRIPTION
This pull request refactors how category ordering is handled in the blog's sidebar. Previously, each category's order was specified as a property in the `categoryMeta` object and used for sorting. Now, the order is determined solely by the order of keys in the `categoryKeys` array, simplifying the code and improving maintainability.

**Category ordering refactor:**

* Removed the `order` property from each category's metadata in `categoryMeta`, and eliminated the `MetaWithOrder` type in favor of a simpler `Meta` type. [[1]](diffhunk://#diff-0573a866c1e96f7842a283728c10e89b1f08c0326aaa4445332da20fc21e06caL80-R81) [[2]](diffhunk://#diff-0573a866c1e96f7842a283728c10e89b1f08c0326aaa4445332da20fc21e06caL89-R245) [[3]](diffhunk://#diff-dc1c34abb9cc824399d08a5b2069ec4fac7dca660737360ac543113aa236dd4cL30-L40) [[4]](diffhunk://#diff-0573a866c1e96f7842a283728c10e89b1f08c0326aaa4445332da20fc21e06caL34-R34)
* Updated the code to rely on the order of `categoryKeys` for sidebar ordering, with a note explaining this in the code.
* Removed the explicit sorting by `order` in the `Categories` component, since the order is now defined by the array itself.