### PR TITLE
refactor(*): centralize flex center utility

### DIFF
--- a/apps/blog/src/components/aside/categories.module.css
+++ b/apps/blog/src/components/aside/categories.module.css
@@ -1,3 +1,11 @@
+.react-icons {
+  composes: flex-center from global;
+}
+
+.count-docs {
+  composes: flex-center from global;
+}
+
 .categories {
   --grid-template-rows-1: var(--size-24);
   --grid-template-rows-2: var(--size-16);

--- a/apps/blog/src/components/aside/categories.tsx
+++ b/apps/blog/src/components/aside/categories.tsx
@@ -14,7 +14,6 @@ import 'server-only';
 
 import Link from 'next/link';
 import { FaPen } from '@lumir/react-kit/svgs';
-import { cn } from '@lumir/utils';
 import { categoryMeta } from '@/data/category';
 import { type PropsWithLang } from '@/data/lang';
 import createMarkdownCollection from '@/utils/markdown-collection';
@@ -45,13 +44,11 @@ export default async function Categories({ lang }: PropsWithLang) {
               className="custom-hover-effect"
               href={`/${lang}/categories/${categoryKey}`}
             >
-              <div className={cn(styles['react-icons'], 'custom-flex-center')}>
-                {reactIcons}
-              </div>
+              <div className={styles['react-icons']}>{reactIcons}</div>
               <div className={styles['name-en']}>{en}</div>
               <div className={styles['name-ko']}>{ko}</div>
-              <div className={cn(styles['count-docs'], 'custom-flex-center')}>
-                <span className="custom-flex-center">
+              <div className={styles['count-docs']}>
+                <span className="flex-center">
                   {markdownCollection.byLangCategory[lang][categoryKey].length}
                 </span>
                 <FaPen />

--- a/apps/blog/src/components/aside/links.module.css
+++ b/apps/blog/src/components/aside/links.module.css
@@ -1,4 +1,5 @@
 .links {
+  composes: flex-center from global;
   padding: var(--size-8) 0 var(--size-16);
   list-style: none;
 

--- a/apps/blog/src/components/aside/links.tsx
+++ b/apps/blog/src/components/aside/links.tsx
@@ -27,20 +27,17 @@ export default async function Links({ lang }: PropsWithLang) {
   const { html_url: htmlUrl } = await getGithubUsers();
 
   return (
-    <ul className={cn(styles.links, 'custom-flex-center')}>
+    <ul className={styles.links}>
       <li>
-        <Link
-          className={cn('custom-flex-center', 'custom-hover-effect')}
-          href={`/${lang}`}
-        >
+        <Link className={cn('flex-center', 'custom-hover-effect')} href={`/${lang}`}>
           <FaHouseChimney />
-          <span className="custom-flex-center">Home</span>
+          <span className="flex-center">Home</span>
         </Link>
       </li>
       <li>
-        <Link className={cn('custom-flex-center', 'custom-hover-effect')} href={htmlUrl}>
+        <Link className={cn('flex-center', 'custom-hover-effect')} href={htmlUrl}>
           <FaGithub />
-          <span className="custom-flex-center">GitHub</span>
+          <span className="flex-center">GitHub</span>
         </Link>
       </li>
     </ul>

--- a/apps/blog/src/components/aside/profile.module.css
+++ b/apps/blog/src/components/aside/profile.module.css
@@ -1,4 +1,5 @@
 .profile {
+  composes: flex-center from global;
   flex-direction: column;
   margin: var(--size-16);
 

--- a/apps/blog/src/components/aside/profile.tsx
+++ b/apps/blog/src/components/aside/profile.tsx
@@ -13,7 +13,6 @@ import 'server-only';
 // --------------------------------------------------------------------------------
 
 import Link from 'next/link';
-import { cn } from '@lumir/utils';
 import { type PropsWithLang } from '@/data/lang';
 import { getGithubUsers } from '@/utils/fetch';
 import styles from './profile.module.css';
@@ -26,7 +25,7 @@ export default async function Profile({ lang }: PropsWithLang) {
   const { avatar_url: avatarUrl, bio, name } = await getGithubUsers();
 
   return (
-    <div className={cn(styles.profile, 'custom-flex-center')}>
+    <div className={styles.profile}>
       <img
         src={(() => {
           // To avoid downloading a much larger image than needed,

--- a/apps/blog/src/components/common/loading.module.css
+++ b/apps/blog/src/components/common/loading.module.css
@@ -1,4 +1,6 @@
 .loading {
+  composes: flex-center from global;
+
   & > div {
     flex-direction: column;
 

--- a/apps/blog/src/components/common/loading.tsx
+++ b/apps/blog/src/components/common/loading.tsx
@@ -6,7 +6,6 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { cn } from '@lumir/utils';
 import styles from './loading.module.css';
 
 // --------------------------------------------------------------------------------
@@ -15,8 +14,8 @@ import styles from './loading.module.css';
 
 export default function Loading({ content }: { content: string }) {
   return (
-    <div className={cn(styles.loading, 'custom-flex-center')}>
-      <div className="custom-flex-center">
+    <div className={styles.loading}>
+      <div className="flex-center">
         <div>
           <img
             src="/images/loading.gif"

--- a/apps/blog/src/components/header/doc-search.module.css
+++ b/apps/blog/src/components/header/doc-search.module.css
@@ -1,4 +1,5 @@
 .doc-search {
+  composes: flex-center from global;
   margin: var(--size-10) var(--size-8) var(--size-10) 0;
 
   @media (width >= 768px) {

--- a/apps/blog/src/components/header/doc-search.tsx
+++ b/apps/blog/src/components/header/doc-search.tsx
@@ -19,7 +19,6 @@ import 'client-only';
 // --------------------------------------------------------------------------------
 
 import { DocSearch as DocSearchOriginal } from '@docsearch/react';
-import { cn } from '@lumir/utils';
 import styles from './doc-search.module.css';
 import '@docsearch/css';
 import './doc-search.css';
@@ -30,7 +29,7 @@ import './doc-search.css';
 
 export default function DocSearch() {
   return (
-    <div className={cn(styles['doc-search'], 'custom-flex-center')}>
+    <div className={styles['doc-search']}>
       <DocSearchOriginal
         // required
         appId="TDWHMEE0BV"

--- a/apps/blog/src/components/header/lang-toggle.module.css
+++ b/apps/blog/src/components/header/lang-toggle.module.css
@@ -1,4 +1,6 @@
 .lang-toggle {
+  composes: flex-center from global;
+
   > a {
     width: var(--size-32);
     height: var(--size-32);

--- a/apps/blog/src/components/header/lang-toggle.tsx
+++ b/apps/blog/src/components/header/lang-toggle.tsx
@@ -44,14 +44,14 @@ export default function LangToggle({ lang }: PropsWithLang) {
   const href = `/${[nextLang, ...layoutSegments].join('/')}` as const;
 
   return (
-    <div className={cn(styles['lang-toggle'], 'custom-flex-center')}>
+    <div className={styles['lang-toggle']}>
       {/*
        * Use a native anchor intentionally so switching languages performs a full-page navigation.
        * Each localized route owns document-level state such as `<html lang>`, and a fresh document
        * also reruns `ThemeScript` before hydration to restore the persisted `data-theme` safely.
        */}
       <a
-        className={cn('custom-flex-center', 'custom-hover-effect')}
+        className={cn('flex-center', 'custom-hover-effect')}
         href={href}
         aria-label={ariaLabelByLang[lang]}
       >

--- a/apps/blog/src/components/header/theme-toggle.module.css
+++ b/apps/blog/src/components/header/theme-toggle.module.css
@@ -1,4 +1,6 @@
 .theme-toggle {
+  composes: flex-center from global;
+
   &:hover {
     animation: var(--animation-shake);
   }

--- a/apps/blog/src/components/header/theme-toggle.tsx
+++ b/apps/blog/src/components/header/theme-toggle.tsx
@@ -30,7 +30,7 @@ export default function ThemeToggle() {
   const [theme, toggleTheme] = useThemeContext();
 
   return (
-    <div className={cn(styles['theme-toggle'], 'custom-flex-center')}>
+    <div className={styles['theme-toggle']}>
       <button
         type="button"
         className={styles.switch}

--- a/apps/blog/src/components/header/title.module.css
+++ b/apps/blog/src/components/header/title.module.css
@@ -1,4 +1,6 @@
 .title {
+  composes: flex-center from global;
+
   & > a > img {
     border-radius: 50%;
   }

--- a/apps/blog/src/components/header/title.tsx
+++ b/apps/blog/src/components/header/title.tsx
@@ -13,7 +13,6 @@ import 'server-only';
 // --------------------------------------------------------------------------------
 
 import Link from 'next/link';
-import { cn } from '@lumir/utils';
 import { type PropsWithLang } from '@/data/lang';
 import { getGithubUsers } from '@/utils/fetch';
 import styles from './title.module.css';
@@ -26,7 +25,7 @@ export default async function Title({ lang }: PropsWithLang) {
   const { avatar_url: avatarUrl, bio, name } = await getGithubUsers();
 
   return (
-    <div className={cn(styles.title, 'custom-flex-center')}>
+    <div className={styles.title}>
       <Link href={`/${lang}`}>
         <img
           src={(() => {

--- a/apps/blog/src/components/layouts/aside.module.css
+++ b/apps/blog/src/components/layouts/aside.module.css
@@ -25,6 +25,7 @@
 }
 
 .div {
+  composes: flex-center from global;
   position: fixed;
   top: calc(
     var(--size-scroll-progress-height) + var(--size-header-height)

--- a/apps/blog/src/components/layouts/aside.tsx
+++ b/apps/blog/src/components/layouts/aside.tsx
@@ -42,10 +42,7 @@ export default function Aside({ children }: PropsWithChildren) {
       >
         {children}
       </aside>
-      <div
-        className={cn(styles.div, visible && styles.visible, 'custom-flex-center')}
-        onClick={toggleVisible}
-      >
+      <div className={cn(styles.div, visible && styles.visible)} onClick={toggleVisible}>
         <HiOutlineMenuAlt2 />
       </div>
     </>

--- a/apps/blog/src/components/nav/sort.module.css
+++ b/apps/blog/src/components/nav/sort.module.css
@@ -1,3 +1,11 @@
+.react-icons {
+  composes: flex-center from global;
+}
+
+.sort {
+  composes: flex-center from global;
+}
+
 .list {
   padding: 0;
   margin: 0;

--- a/apps/blog/src/components/nav/sort.tsx
+++ b/apps/blog/src/components/nav/sort.tsx
@@ -40,14 +40,12 @@ function SortContainer({ children }: PropsWithChildren) {
         className={cn(styles['sort-item'], 'custom-hover-effect')}
         onClick={toggleIsOpen}
       >
-        <div className={cn(styles['react-icons'], 'custom-flex-center')}>
+        <div className={styles['react-icons']}>
           <GrSort />
         </div>
         <div className={styles['name-en']}>Sort</div>
         <div className={styles['name-ko']}>정렬</div>
-        <div className={cn(styles.sort, 'custom-flex-center')}>
-          {isOpen ? <FaAngleUp /> : <FaAngleDown />}
-        </div>
+        <div className={styles.sort}>{isOpen ? <FaAngleUp /> : <FaAngleDown />}</div>
       </div>
       {isOpen ? <ul className={styles.list}>{children}</ul> : null}
     </div>
@@ -69,18 +67,14 @@ function SortItem({ field, sort }: { field: SortableFrontmatterKey; sort: SortKe
 
   return (
     <li className={cn(styles['sort-item'], 'custom-hover-effect')} onClick={onClick}>
-      <div className={cn(styles['react-icons'], 'custom-flex-center')}>
-        {frontmatterMeta[field].reactIcons}
-      </div>
+      <div className={styles['react-icons']}>{frontmatterMeta[field].reactIcons}</div>
       <div
         className={styles['name-en']}
       >{`${frontmatterMeta[field].name.en} / ${sortMeta[sort].name.en}`}</div>
       <div
         className={styles['name-ko']}
       >{`${frontmatterMeta[field].name.ko} / ${sortMeta[sort].name.ko}`}</div>
-      <div className={cn(styles.sort, 'custom-flex-center')}>
-        {sortMeta[sort].reactIcons}
-      </div>
+      <div className={styles.sort}>{sortMeta[sort].reactIcons}</div>
     </li>
   );
 }

--- a/apps/blog/src/styles/index.css
+++ b/apps/blog/src/styles/index.css
@@ -1,6 +1,7 @@
 /* External */
 @import '@lumir/styles/normalize.css';
 @import '@lumir/styles/animations.css';
+@import '@lumir/styles/utilities.css';
 @import 'katex/dist/katex.min.css';
 
 /* Internal */

--- a/apps/blog/src/styles/utilities.css
+++ b/apps/blog/src/styles/utilities.css
@@ -1,9 +1,3 @@
-.custom-flex-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .custom-hover-effect {
   transition: all 0.3s ease-in-out;
 

--- a/apps/moing/src/app.tsx
+++ b/apps/moing/src/app.tsx
@@ -86,7 +86,7 @@ export default function App() {
 
       <Timer currentCount={currentCount} />
 
-      <main className={cn('custom-flex-center', 'custom-scrollbar')}>
+      <main className={cn('flex-center', 'custom-scrollbar')}>
         <div ref={scrollRef}>
           <Title />
           <Server

--- a/apps/moing/src/components/button.tsx
+++ b/apps/moing/src/components/button.tsx
@@ -41,7 +41,7 @@ export default function Button({ type, icon, onClick, hoverEffect = false }: Pro
     <div
       className={cn(
         `${type}`,
-        'custom-flex-center',
+        'flex-center',
         'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
         status === 'visible' && 'pointer-events-none',

--- a/apps/moing/src/components/config.module.css
+++ b/apps/moing/src/components/config.module.css
@@ -1,4 +1,5 @@
 .config {
+  composes: flex-center from global;
   height: calc(var(--main-section-height) * 1.5);
 
   & > div {

--- a/apps/moing/src/components/config.tsx
+++ b/apps/moing/src/components/config.tsx
@@ -96,7 +96,6 @@ export default function Config() {
     <NeonDiv
       className={cn(
         styles.config,
-        'custom-flex-center',
         'custom-scrollbar',
         'custom-main-section',
         'transition',

--- a/apps/moing/src/components/main-button.module.css
+++ b/apps/moing/src/components/main-button.module.css
@@ -1,4 +1,5 @@
 .main-button {
+  composes: flex-center from global;
   animation:
     4s ease-in-out 4s backwards global(fade-in),
     8s ease-in-out pointer-events-none;

--- a/apps/moing/src/components/main-button.tsx
+++ b/apps/moing/src/components/main-button.tsx
@@ -48,7 +48,6 @@ export default function ButtonMain() {
     <div
       className={cn(
         styles['main-button'],
-        'custom-flex-center',
         'custom-main-others',
         'transition',
         (isLastSection() && isConfigDone()) || status !== 'hidden'

--- a/apps/moing/src/components/timer.tsx
+++ b/apps/moing/src/components/timer.tsx
@@ -39,7 +39,7 @@ export default function Timer({ currentCount }: TimerProps) {
     <footer
       className={cn(
         'timer',
-        'custom-flex-center',
+        'flex-center',
         'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
       )}

--- a/apps/moing/src/styles/index.css
+++ b/apps/moing/src/styles/index.css
@@ -1,6 +1,7 @@
 /* External */
 @import '@lumir/styles/normalize.css';
 @import '@lumir/styles/animations.css';
+@import '@lumir/styles/utilities.css';
 
 /* Internal */
 @import './typography.css';

--- a/apps/moing/src/styles/utilities.css
+++ b/apps/moing/src/styles/utilities.css
@@ -1,9 +1,3 @@
-.custom-flex-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .custom-scrollbar {
   overflow-y: auto;
 

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./animations.css": "./src/animations.css",
     "./normalize.css": "./src/normalize.css",
+    "./utilities.css": "./src/utilities.css",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/styles/src/utilities.css
+++ b/packages/styles/src/utilities.css
@@ -1,0 +1,5 @@
+.flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary

- Add a shared `flex-center` utility to `@lumir/styles` and remove duplicate app-level definitions.
- Compose the shared utility from component CSS Modules when a local class already exists.
- Keep direct `flex-center` usage for elements without a local CSS Module class.

## Scope

- `packages/styles`
- `apps/blog`
- `apps/moing`

## Validation

- `npm run test` — 317 unit/browser tests and 4 Playwright E2E tests passed
- `npm run build:pkg`
- `npm run build:b`
- `npm run build:m`
- `npm run lint` — passed with 5 existing warnings

## Notes

- Direct `flex-center` usages without `styles.*` remain unchanged.