### PR TITLE
feat(blog): preserve URL state when switching languages

### DIFF
--- a/apps/blog/playwright.config.js
+++ b/apps/blog/playwright.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
       ],
   retries: isCI ? 1 : 0,
   testDir: './tests',
+  workers: '75%',
 
   projects: [
     {
@@ -46,6 +47,6 @@ export default defineConfig({
   webServer: {
     command: 'node --run dev',
     url,
-    reuseExistingServer: false,
+    reuseExistingServer: !isCI,
   },
 });

--- a/apps/blog/src/components/lang-toggle.tsx
+++ b/apps/blog/src/components/lang-toggle.tsx
@@ -2,8 +2,6 @@
  * @fileoverview lang-toggle.
  */
 
-// TODO: handle search params and hash params when switching language.
-
 // --------------------------------------------------------------------------------
 // Directive
 // --------------------------------------------------------------------------------
@@ -56,6 +54,12 @@ export function LangToggle({ lang }: PropsWithLang) {
       <a
         className="custom-hover-effect"
         href={href}
+        onClick={e => {
+          // Preserve search params and hash params when switching language.
+          const url = new URL(window.location.href);
+          url.pathname = url.pathname.replace(`/${lang}`, `/${nextLang}`);
+          e.currentTarget.href = url.href;
+        }}
         aria-label={dictionary[lang].ariaLabel}
       >
         {nextLang}

--- a/apps/blog/tests/no-javascript.test.ts
+++ b/apps/blog/tests/no-javascript.test.ts
@@ -59,6 +59,26 @@ test.describe('pages rendered without JavaScript', () => {
         page.getByRole('heading', { level: 3, name: /1-1\. What Is Markdown\?/ }),
       ).toBeVisible();
     });
+
+    test('Korean post language toggle should preserve the post pathname', async ({
+      page,
+    }) => {
+      const response = await page.goto('/ko/posts/everything-about-markdown#usage-guide');
+
+      expect(response?.status()).toBe(200);
+
+      const langToggle = page.getByRole('link', {
+        name: '언어를 영어로 전환',
+      });
+
+      await expect(langToggle).toHaveAttribute(
+        'href',
+        '/en/posts/everything-about-markdown',
+      );
+      await langToggle.click();
+      await expect(page).toHaveURL(/\/en\/posts\/everything-about-markdown$/);
+      await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    });
   });
 
   test.describe('categories', () => {
@@ -102,6 +122,23 @@ test.describe('pages rendered without JavaScript', () => {
         'href',
         '/en/posts/everything-about-markdown',
       );
+    });
+
+    test('Korean category language toggle should preserve the category pathname', async ({
+      page,
+    }) => {
+      const response = await page.goto('/ko/categories/markdown?field=title&sort=asc');
+
+      expect(response?.status()).toBe(200);
+
+      const langToggle = page.getByRole('link', {
+        name: '언어를 영어로 전환',
+      });
+
+      await expect(langToggle).toHaveAttribute('href', '/en/categories/markdown');
+      await langToggle.click();
+      await expect(page).toHaveURL(/\/en\/categories\/markdown$/);
+      await expect(page.locator('html')).toHaveAttribute('lang', 'en');
     });
   });
 });


### PR DESCRIPTION
This pull request improves the language toggle functionality in the blog application to better handle URL parameters and enhances test coverage to ensure correct behavior. It also includes configuration updates for Playwright to optimize test execution.

**Language Toggle Functionality Improvements:**

* Updated the `LangToggle` component to preserve search and hash parameters when switching languages, ensuring users remain on the same page context after toggling the language.
* Removed a TODO comment in `lang-toggle.tsx` as the search and hash parameter handling is now implemented.

**Testing Enhancements:**

* Added Playwright tests to verify that language toggling on Korean post and category pages preserves the correct pathname and updates the language as expected. [[1]](diffhunk://#diff-7f3ee13377d812a5e24917bff8ae676190a3c93259209b6d917e98d3c02ea1a2R62-R81) [[2]](diffhunk://#diff-7f3ee13377d812a5e24917bff8ae676190a3c93259209b6d917e98d3c02ea1a2R126-R142)

**Test Configuration Updates:**

* Set the number of Playwright workers to 75% of available CPUs for more efficient test runs.
* Modified the Playwright web server configuration to reuse the existing server when not in CI, reducing setup time during local development.