### PR TITLE
feat(@lumir/react-kit): add `cursor-splash` component

### DIFF
--- a/apps/blog/src/app/[lang]/layout.tsx
+++ b/apps/blog/src/app/[lang]/layout.tsx
@@ -12,6 +12,7 @@ import { type PropsWithChildren } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
+import { CursorSplash } from '@/components/cursor-splash';
 import { GoogleAnalytics } from '@/components/google-analytics';
 import { ThemeProvider } from '@/components/theme-context';
 import { ThemeScript } from '@/components/theme-script';
@@ -80,6 +81,7 @@ export default async function RootLayout({
     <html className="custom-scrollbar-y-bold" lang={lang} suppressHydrationWarning>
       <body className={styles.body}>
         <ThemeScript />
+        <CursorSplash />
         <ThemeProvider>
           <ScrollProgress className={styles['scroll-progress']} />
           <header>

--- a/apps/blog/src/components/cursor-splash.module.css
+++ b/apps/blog/src/components/cursor-splash.module.css
@@ -1,0 +1,16 @@
+.cursor-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: 0.1;
+  filter: grayscale(1);
+
+  & > canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/apps/blog/src/components/cursor-splash.tsx
+++ b/apps/blog/src/components/cursor-splash.tsx
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Consumer-controlled cursor splash effect.
+ */
+
+// --------------------------------------------------------------------------------
+// Directive
+// --------------------------------------------------------------------------------
+
+'use client';
+
+// --------------------------------------------------------------------------------
+// Environment
+// --------------------------------------------------------------------------------
+
+import 'client-only';
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { CursorSplash as CursorSplashOriginal } from '@lumir/react-kit/components';
+import { useEffect, useState } from 'react';
+import styles from './cursor-splash.module.css';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+const cursorSplashMediaQuery =
+  '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Renders the cursor splash effect when the consumer media query matches.
+ */
+export function CursorSplash() {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(cursorSplashMediaQuery);
+
+    function updateEnabled() {
+      setEnabled(mediaQueryList.matches);
+    }
+
+    updateEnabled();
+    mediaQueryList.addEventListener('change', updateEnabled);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', updateEnabled);
+    };
+  }, []);
+
+  if (!enabled) {
+    return null;
+  } else {
+    return (
+      <CursorSplashOriginal className={styles['cursor-splash']} aria-hidden="true" />
+    );
+  }
+}

--- a/apps/blog/src/styles/variables.css
+++ b/apps/blog/src/styles/variables.css
@@ -34,7 +34,7 @@ html[data-theme='dark'] {
   --color-fg-attention: #d29922;
   --color-fg-danger: #f85149;
   --color-fg-done: #ab7df8;
-  --color-bg-inset: #010409; /* custom color */
+  --color-bg-inset: #010400; /* custom color */
   --color-bg-default: #0d1117;
   --color-bg-muted: #151b23;
   --color-bg-neutral-muted: #656c7633;

--- a/packages/react-kit/src/components/cursor-splash.test-d.tsx
+++ b/packages/react-kit/src/components/cursor-splash.test-d.tsx
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Type test for `cursor-splash.tsx`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { type ComponentProps, type ReactElement } from 'react';
+import { CursorSplash, type CursorSplashProps } from './cursor-splash.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region CursorSplashProps
+
+let props: CursorSplashProps;
+
+props = {};
+props = { className: 'cursor-splash' };
+props = { SIM_RESOLUTION: 128 };
+props = { DYE_RESOLUTION: 1_440 };
+props = { DENSITY_DISSIPATION: 3.5 };
+props = { VELOCITY_DISSIPATION: 2 };
+props = { PRESSURE: 0.1 };
+props = { PRESSURE_ITERATIONS: 20 };
+props = { CURL: 3 };
+props = { SPLAT_RADIUS: 0.2 };
+props = { SPLAT_FORCE: 6_000 };
+props = { SHADING: true };
+props = { COLOR_UPDATE_SPEED: 10 };
+props = { BACK_COLOR: { r: 0.5, g: 0, b: 0 } };
+props = { TRANSPARENT: true };
+props = { RAINBOW_MODE: false };
+props = { COLOR: '#ff0000' };
+props = { 'aria-hidden': true, id: 'cursor-effect' };
+
+// @ts-expect-error - `SIM_RESOLUTION` should be a number.
+props = { SIM_RESOLUTION: '128' };
+// @ts-expect-error - `SHADING` should be a boolean.
+props = { SHADING: 'true' };
+// @ts-expect-error - `canvasClassName` is not a supported property.
+props = { canvasClassName: 'cursor-splash-canvas' };
+// @ts-expect-error - `children` are not supported.
+props = { children: <span /> };
+// @ts-expect-error - `unknown` is not a valid property of `CursorSplashProps`.
+props = { unknown: 'unknown' };
+
+// #endregion CursorSplashProps
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region CursorSplash
+
+({}) as typeof CursorSplash satisfies Function;
+({}) as Parameters<typeof CursorSplash>[0] satisfies CursorSplashProps;
+({}) as ComponentProps<typeof CursorSplash> satisfies CursorSplashProps;
+({}) as ReturnType<typeof CursorSplash> satisfies ReactElement;
+
+// @ts-expect-error - `CursorSplash` should be a function.
+({}) as typeof CursorSplash satisfies boolean;
+// @ts-expect-error - `CursorSplash` should be a function.
+({}) as typeof CursorSplash satisfies string;
+
+function CursorSplashTypeTest() {
+  return [
+    <CursorSplash key="default" />,
+    <CursorSplash key="styled" className="cursor-splash" />,
+    <CursorSplash key="configured" RAINBOW_MODE={false} COLOR="#ffffff" />,
+
+    // @ts-expect-error - `COLOR` should be a string.
+    <CursorSplash key="invalid-color" COLOR={false} />,
+    // @ts-expect-error - `children` are not supported.
+    <CursorSplash key="invalid-children">
+      <span />
+    </CursorSplash>,
+  ];
+}
+
+// #endregion CursorSplash
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/components/cursor-splash.test.tsx
+++ b/packages/react-kit/src/components/cursor-splash.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Test for `cursor-splash.tsx`.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { assert, describe, it } from 'vitest';
+import { render } from 'vitest-browser-react';
+import { CursorSplash } from './cursor-splash.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('cursor-splash', () => {
+  it('should leave visual styling to consumer-provided classes', async () => {
+    const screen = await render(
+      <CursorSplash className="cursor-splash" id="cursor-effect" aria-hidden="true" />,
+    );
+
+    const container = screen.container.querySelector('#cursor-effect');
+    const canvas = container?.querySelector('canvas');
+
+    assert.ok(container);
+    assert.ok(canvas);
+    assert.strictEqual(container.className, 'cursor-splash');
+    assert.strictEqual(container.getAttribute('aria-hidden'), 'true');
+    assert.strictEqual(container.getAttribute('style'), null);
+    assert.strictEqual(canvas.getAttribute('class'), null);
+    assert.strictEqual(canvas.getAttribute('id'), null);
+    assert.strictEqual(canvas.getAttribute('style'), null);
+  });
+});

--- a/packages/react-kit/src/components/cursor-splash.tsx
+++ b/packages/react-kit/src/components/cursor-splash.tsx
@@ -1,0 +1,1552 @@
+/**
+ * @fileoverview Headless WebGL fluid cursor effect.
+ * @see https://github.com/DavidHDev/react-bits/blob/1320d40a8318ac7d4fe6690c7206ceda8cdd59bd/src/ts-tailwind/Animations/SplashCursor/SplashCursor.tsx
+ * @see https://github.com/bepyan/bepyan.me.v2/blob/main/src/components/cursor-splash.tsx
+ */
+
+/* eslint-disable @typescript-eslint/no-shadow, max-classes-per-file, react/no-this-in-sfc */
+
+// --------------------------------------------------------------------------------
+// Directive
+// --------------------------------------------------------------------------------
+
+'use client';
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useEffect, useRef, type HTMLAttributes } from 'react';
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+interface ColorRGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface Pointer {
+  id: number;
+  texcoordX: number;
+  texcoordY: number;
+  prevTexcoordX: number;
+  prevTexcoordY: number;
+  deltaX: number;
+  deltaY: number;
+  down: boolean;
+  moved: boolean;
+  color: ColorRGB;
+}
+
+interface TextureFormat {
+  internalFormat: number;
+  format: number;
+}
+
+export interface CursorSplashProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children'
+> {
+  SIM_RESOLUTION?: number;
+  DYE_RESOLUTION?: number;
+  CAPTURE_RESOLUTION?: number;
+  DENSITY_DISSIPATION?: number;
+  VELOCITY_DISSIPATION?: number;
+  PRESSURE?: number;
+  PRESSURE_ITERATIONS?: number;
+  CURL?: number;
+  SPLAT_RADIUS?: number;
+  SPLAT_FORCE?: number;
+  SHADING?: boolean;
+  COLOR_UPDATE_SPEED?: number;
+  BACK_COLOR?: ColorRGB;
+  TRANSPARENT?: boolean;
+  RAINBOW_MODE?: boolean;
+  COLOR?: string;
+}
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * Renders an unstyled canvas and simulates a fluid trail from pointer input.
+ *
+ * The component owns only the WebGL behavior. Apply positioning, sizing,
+ * pointer-event, opacity, and color-filter styles from the consuming app by
+ * passing `className` and selecting the nested canvas.
+ *
+ * @example `component.tsx`
+ * ```tsx
+ * import { CursorSplash } from '@lumir/react-kit/components';
+ * import styles from './component.module.css';
+ *
+ * function Component() {
+ *   return <CursorSplash className={styles['cursor-splash']} aria-hidden="true" />;
+ * }
+ * ```
+ *
+ * @example `component.module.css`
+ * ```css
+ * .cursor-splash {
+ *   position: fixed;
+ *   top: 0;
+ *   left: 0;
+ *   z-index: 50;
+ *   width: 100%;
+ *   height: 100%;
+ *   pointer-events: none;
+ *
+ *   & > canvas {
+ *     display: block;
+ *     width: 100vw;
+ *     height: 100vh;
+ *   }
+ * }
+ * ```
+ */
+export function CursorSplash({
+  SIM_RESOLUTION = 128,
+  DYE_RESOLUTION = 1440,
+  CAPTURE_RESOLUTION = 512,
+  DENSITY_DISSIPATION = 3.5,
+  VELOCITY_DISSIPATION = 2,
+  PRESSURE = 0.1,
+  PRESSURE_ITERATIONS = 20,
+  CURL = 3,
+  SPLAT_RADIUS = 0.2,
+  SPLAT_FORCE = 6000,
+  SHADING = true,
+  COLOR_UPDATE_SPEED = 10,
+  BACK_COLOR = { r: 0.5, g: 0, b: 0 },
+  TRANSPARENT = true,
+  RAINBOW_MODE = true,
+  COLOR = '#ff0000',
+  ...props
+}: CursorSplashProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+
+    const pointers: Pointer[] = [
+      {
+        id: -1,
+        texcoordX: 0,
+        texcoordY: 0,
+        prevTexcoordX: 0,
+        prevTexcoordY: 0,
+        deltaX: 0,
+        deltaY: 0,
+        down: false,
+        moved: false,
+        color: { r: 0, g: 0, b: 0 },
+      },
+    ];
+
+    const config = {
+      SIM_RESOLUTION,
+      DYE_RESOLUTION,
+      CAPTURE_RESOLUTION,
+      DENSITY_DISSIPATION,
+      VELOCITY_DISSIPATION,
+      PRESSURE,
+      PRESSURE_ITERATIONS,
+      CURL,
+      SPLAT_RADIUS,
+      SPLAT_FORCE,
+      SHADING,
+      COLOR_UPDATE_SPEED,
+      PAUSED: false,
+      BACK_COLOR,
+      TRANSPARENT,
+      RAINBOW_MODE,
+      COLOR,
+    };
+
+    const { gl, ext } = getWebGLContext(canvas);
+    if (!gl || !ext) return undefined;
+
+    const abortController = new AbortController();
+    const { signal } = abortController;
+
+    if (!ext.supportLinearFiltering) {
+      config.DYE_RESOLUTION = 256;
+      config.SHADING = false;
+    }
+
+    function getWebGLContext(canvas: HTMLCanvasElement) {
+      const params = {
+        alpha: true,
+        depth: false,
+        stencil: false,
+        antialias: false,
+        preserveDrawingBuffer: false,
+      };
+
+      let gl = canvas.getContext('webgl2', params) as WebGL2RenderingContext | null;
+
+      if (!gl) {
+        gl = (canvas.getContext('webgl', params) ||
+          canvas.getContext(
+            'experimental-webgl',
+            params,
+          )) as WebGL2RenderingContext | null;
+      }
+
+      if (!gl) {
+        throw new Error('Unable to initialize WebGL.');
+      }
+
+      const isWebGL2 = 'drawBuffers' in gl;
+
+      let supportLinearFiltering: boolean;
+      let halfFloat: { HALF_FLOAT_OES: number } | null = null;
+
+      if (isWebGL2) {
+        (gl as WebGL2RenderingContext).getExtension('EXT_color_buffer_float');
+        supportLinearFiltering = !!(gl as WebGL2RenderingContext).getExtension(
+          'OES_texture_float_linear',
+        );
+      } else {
+        halfFloat = gl.getExtension('OES_texture_half_float');
+        supportLinearFiltering = !!gl.getExtension('OES_texture_half_float_linear');
+      }
+
+      gl.clearColor(0, 0, 0, 1);
+
+      const halfFloatTexType = isWebGL2
+        ? (gl as WebGL2RenderingContext).HALF_FLOAT
+        : (halfFloat && halfFloat.HALF_FLOAT_OES) || 0;
+
+      let formatRGBA: TextureFormat | null;
+      let formatRG: TextureFormat | null;
+      let formatR: TextureFormat | null;
+
+      if (isWebGL2) {
+        formatRGBA = getSupportedFormat(
+          gl,
+          (gl as WebGL2RenderingContext).RGBA16F,
+          gl.RGBA,
+          halfFloatTexType,
+        );
+        formatRG = getSupportedFormat(
+          gl,
+          (gl as WebGL2RenderingContext).RG16F,
+          (gl as WebGL2RenderingContext).RG,
+          halfFloatTexType,
+        );
+        formatR = getSupportedFormat(
+          gl,
+          (gl as WebGL2RenderingContext).R16F,
+          (gl as WebGL2RenderingContext).RED,
+          halfFloatTexType,
+        );
+      } else {
+        formatRGBA = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
+        formatRG = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
+        formatR = getSupportedFormat(gl, gl.RGBA, gl.RGBA, halfFloatTexType);
+      }
+
+      if (!formatRGBA || !formatRG || !formatR) {
+        throw new Error('Unable to initialize WebGL render texture formats.');
+      }
+
+      return {
+        gl,
+        ext: {
+          formatRGBA,
+          formatRG,
+          formatR,
+          halfFloatTexType,
+          supportLinearFiltering,
+        },
+      };
+    }
+
+    function getSupportedFormat(
+      gl: WebGLRenderingContext | WebGL2RenderingContext,
+      internalFormat: number,
+      format: number,
+      type: number,
+    ): TextureFormat | null {
+      if (!supportRenderTextureFormat(gl, internalFormat, format, type)) {
+        if ('drawBuffers' in gl) {
+          const gl2 = gl as WebGL2RenderingContext;
+          switch (internalFormat) {
+            case gl2.R16F:
+              return getSupportedFormat(gl2, gl2.RG16F, gl2.RG, type);
+            case gl2.RG16F:
+              return getSupportedFormat(gl2, gl2.RGBA16F, gl2.RGBA, type);
+            default:
+              return null;
+          }
+        }
+        return null;
+      }
+      return { internalFormat, format };
+    }
+
+    function supportRenderTextureFormat(
+      gl: WebGLRenderingContext | WebGL2RenderingContext,
+      internalFormat: number,
+      format: number,
+      type: number,
+    ) {
+      const texture = gl.createTexture();
+      if (!texture) return false;
+
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 4, 4, 0, format, type, null);
+
+      const fbo = gl.createFramebuffer();
+      if (!fbo) return false;
+
+      gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+      gl.framebufferTexture2D(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.TEXTURE_2D,
+        texture,
+        0,
+      );
+      const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+      return status === gl.FRAMEBUFFER_COMPLETE;
+    }
+
+    function hashCode(s: string) {
+      if (!s.length) return 0;
+      let hash = 0;
+      for (let i = 0; i < s.length; i++) {
+        /* eslint-disable no-bitwise */
+        hash = (hash << 5) - hash + s.charCodeAt(i);
+        hash |= 0;
+        /* eslint-enable no-bitwise */
+      }
+      return hash;
+    }
+
+    function addKeywords(source: string, keywords: string[] | null) {
+      if (!keywords) return source;
+      let keywordsString = '';
+      for (const keyword of keywords) {
+        keywordsString += `#define ${keyword}\n`;
+      }
+      return keywordsString + source;
+    }
+
+    function compileShader(
+      type: number,
+      source: string,
+      keywords: string[] | null = null,
+    ): WebGLShader | null {
+      const shaderSource = addKeywords(source, keywords);
+      const shader = gl.createShader(type);
+      if (!shader) return null;
+      gl.shaderSource(shader, shaderSource);
+      gl.compileShader(shader);
+      if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        // eslint-disable-next-line no-console -- Preserve upstream WebGL diagnostics.
+        console.trace(gl.getShaderInfoLog(shader));
+      }
+      return shader;
+    }
+
+    function createProgram(
+      vertexShader: WebGLShader | null,
+      fragmentShader: WebGLShader | null,
+    ): WebGLProgram | null {
+      if (!vertexShader || !fragmentShader) return null;
+      const program = gl.createProgram();
+      if (!program) return null;
+      gl.attachShader(program, vertexShader);
+      gl.attachShader(program, fragmentShader);
+      gl.linkProgram(program);
+      if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        // eslint-disable-next-line no-console -- Preserve upstream WebGL diagnostics.
+        console.trace(gl.getProgramInfoLog(program));
+      }
+      return program;
+    }
+
+    function getUniforms(program: WebGLProgram) {
+      const uniforms: Record<string, WebGLUniformLocation | null> = {};
+      const uniformCount = gl.getProgramParameter(program, gl.ACTIVE_UNIFORMS);
+      for (let i = 0; i < uniformCount; i++) {
+        const uniformInfo = gl.getActiveUniform(program, i);
+        if (uniformInfo) {
+          uniforms[uniformInfo.name] = gl.getUniformLocation(program, uniformInfo.name);
+        }
+      }
+      return uniforms;
+    }
+
+    class Program {
+      program: WebGLProgram | null;
+      uniforms: Record<string, WebGLUniformLocation | null>;
+
+      constructor(vertexShader: WebGLShader | null, fragmentShader: WebGLShader | null) {
+        this.program = createProgram(vertexShader, fragmentShader);
+        this.uniforms = this.program ? getUniforms(this.program) : {};
+      }
+
+      bind() {
+        if (this.program) gl.useProgram(this.program);
+      }
+    }
+
+    class Material {
+      vertexShader: WebGLShader | null;
+      fragmentShaderSource: string;
+      programs: Record<number, WebGLProgram | null>;
+      activeProgram: WebGLProgram | null;
+      uniforms: Record<string, WebGLUniformLocation | null>;
+
+      constructor(vertexShader: WebGLShader | null, fragmentShaderSource: string) {
+        this.vertexShader = vertexShader;
+        this.fragmentShaderSource = fragmentShaderSource;
+        this.programs = {};
+        this.activeProgram = null;
+        this.uniforms = {};
+      }
+
+      setKeywords(keywords: string[]) {
+        let hash = 0;
+        for (const kw of keywords) {
+          hash += hashCode(kw);
+        }
+        let program = this.programs[hash];
+        if (program == null) {
+          const fragmentShader = compileShader(
+            gl.FRAGMENT_SHADER,
+            this.fragmentShaderSource,
+            keywords,
+          );
+          program = createProgram(this.vertexShader, fragmentShader);
+          this.programs[hash] = program;
+        }
+        if (program === this.activeProgram) return;
+        if (program) {
+          this.uniforms = getUniforms(program);
+        }
+        this.activeProgram = program;
+      }
+
+      bind() {
+        if (this.activeProgram) {
+          gl.useProgram(this.activeProgram);
+        }
+      }
+    }
+
+    const baseVertexShader = compileShader(
+      gl.VERTEX_SHADER,
+      `
+      precision highp float;
+      attribute vec2 aPosition;
+      varying vec2 vUv;
+      varying vec2 vL;
+      varying vec2 vR;
+      varying vec2 vT;
+      varying vec2 vB;
+      uniform vec2 texelSize;
+
+      void main () {
+        vUv = aPosition * 0.5 + 0.5;
+        vL = vUv - vec2(texelSize.x, 0.0);
+        vR = vUv + vec2(texelSize.x, 0.0);
+        vT = vUv + vec2(0.0, texelSize.y);
+        vB = vUv - vec2(0.0, texelSize.y);
+        gl_Position = vec4(aPosition, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const copyShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      uniform sampler2D uTexture;
+
+      void main () {
+          gl_FragColor = texture2D(uTexture, vUv);
+      }
+    `,
+    );
+
+    const clearShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      uniform sampler2D uTexture;
+      uniform float value;
+
+      void main () {
+          gl_FragColor = value * texture2D(uTexture, vUv);
+      }
+    `,
+    );
+
+    const displayShaderSource = `
+      precision highp float;
+      precision highp sampler2D;
+      varying vec2 vUv;
+      varying vec2 vL;
+      varying vec2 vR;
+      varying vec2 vT;
+      varying vec2 vB;
+      uniform sampler2D uTexture;
+      uniform sampler2D uDithering;
+      uniform vec2 ditherScale;
+      uniform vec2 texelSize;
+
+      vec3 linearToGamma (vec3 color) {
+          color = max(color, vec3(0));
+          return max(1.055 * pow(color, vec3(0.416666667)) - 0.055, vec3(0));
+      }
+
+      void main () {
+          vec3 c = texture2D(uTexture, vUv).rgb;
+          #ifdef SHADING
+              vec3 lc = texture2D(uTexture, vL).rgb;
+              vec3 rc = texture2D(uTexture, vR).rgb;
+              vec3 tc = texture2D(uTexture, vT).rgb;
+              vec3 bc = texture2D(uTexture, vB).rgb;
+
+              float dx = length(rc) - length(lc);
+              float dy = length(tc) - length(bc);
+
+              vec3 n = normalize(vec3(dx, dy, length(texelSize)));
+              vec3 l = vec3(0.0, 0.0, 1.0);
+
+              float diffuse = clamp(dot(n, l) + 0.7, 0.7, 1.0);
+              c *= diffuse;
+          #endif
+
+          float a = max(c.r, max(c.g, c.b));
+          gl_FragColor = vec4(c, a);
+      }
+    `;
+
+    const splatShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision highp float;
+      precision highp sampler2D;
+      varying vec2 vUv;
+      uniform sampler2D uTarget;
+      uniform float aspectRatio;
+      uniform vec3 color;
+      uniform vec2 point;
+      uniform float radius;
+
+      void main () {
+          vec2 p = vUv - point.xy;
+          p.x *= aspectRatio;
+          vec3 splat = exp(-dot(p, p) / radius) * color;
+          vec3 base = texture2D(uTarget, vUv).xyz;
+          gl_FragColor = vec4(base + splat, 1.0);
+      }
+    `,
+    );
+
+    const advectionShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision highp float;
+      precision highp sampler2D;
+      varying vec2 vUv;
+      uniform sampler2D uVelocity;
+      uniform sampler2D uSource;
+      uniform vec2 texelSize;
+      uniform vec2 dyeTexelSize;
+      uniform float dt;
+      uniform float dissipation;
+
+      vec4 bilerp (sampler2D sam, vec2 uv, vec2 tsize) {
+          vec2 st = uv / tsize - 0.5;
+          vec2 iuv = floor(st);
+          vec2 fuv = fract(st);
+
+          vec4 a = texture2D(sam, (iuv + vec2(0.5, 0.5)) * tsize);
+          vec4 b = texture2D(sam, (iuv + vec2(1.5, 0.5)) * tsize);
+          vec4 c = texture2D(sam, (iuv + vec2(0.5, 1.5)) * tsize);
+          vec4 d = texture2D(sam, (iuv + vec2(1.5, 1.5)) * tsize);
+
+          return mix(mix(a, b, fuv.x), mix(c, d, fuv.x), fuv.y);
+      }
+
+      void main () {
+          #ifdef MANUAL_FILTERING
+              vec2 coord = vUv - dt * bilerp(uVelocity, vUv, texelSize).xy * texelSize;
+              vec4 result = bilerp(uSource, coord, dyeTexelSize);
+          #else
+              vec2 coord = vUv - dt * texture2D(uVelocity, vUv).xy * texelSize;
+              vec4 result = texture2D(uSource, coord);
+          #endif
+          float decay = 1.0 + dissipation * dt;
+          gl_FragColor = result / decay;
+      }
+    `,
+      ext.supportLinearFiltering ? null : ['MANUAL_FILTERING'],
+    );
+
+    const divergenceShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      varying highp vec2 vL;
+      varying highp vec2 vR;
+      varying highp vec2 vT;
+      varying highp vec2 vB;
+      uniform sampler2D uVelocity;
+
+      void main () {
+          float L = texture2D(uVelocity, vL).x;
+          float R = texture2D(uVelocity, vR).x;
+          float T = texture2D(uVelocity, vT).y;
+          float B = texture2D(uVelocity, vB).y;
+
+          vec2 C = texture2D(uVelocity, vUv).xy;
+          if (vL.x < 0.0) { L = -C.x; }
+          if (vR.x > 1.0) { R = -C.x; }
+          if (vT.y > 1.0) { T = -C.y; }
+          if (vB.y < 0.0) { B = -C.y; }
+
+          float div = 0.5 * (R - L + T - B);
+          gl_FragColor = vec4(div, 0.0, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const curlShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      varying highp vec2 vL;
+      varying highp vec2 vR;
+      varying highp vec2 vT;
+      varying highp vec2 vB;
+      uniform sampler2D uVelocity;
+
+      void main () {
+          float L = texture2D(uVelocity, vL).y;
+          float R = texture2D(uVelocity, vR).y;
+          float T = texture2D(uVelocity, vT).x;
+          float B = texture2D(uVelocity, vB).x;
+          float vorticity = R - L - T + B;
+          gl_FragColor = vec4(0.5 * vorticity, 0.0, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const vorticityShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision highp float;
+      precision highp sampler2D;
+      varying vec2 vUv;
+      varying vec2 vL;
+      varying vec2 vR;
+      varying vec2 vT;
+      varying vec2 vB;
+      uniform sampler2D uVelocity;
+      uniform sampler2D uCurl;
+      uniform float curl;
+      uniform float dt;
+
+      void main () {
+          float L = texture2D(uCurl, vL).x;
+          float R = texture2D(uCurl, vR).x;
+          float T = texture2D(uCurl, vT).x;
+          float B = texture2D(uCurl, vB).x;
+          float C = texture2D(uCurl, vUv).x;
+
+          vec2 force = 0.5 * vec2(abs(T) - abs(B), abs(R) - abs(L));
+          force /= length(force) + 0.0001;
+          force *= curl * C;
+          force.y *= -1.0;
+
+          vec2 velocity = texture2D(uVelocity, vUv).xy;
+          velocity += force * dt;
+          velocity = min(max(velocity, -1000.0), 1000.0);
+          gl_FragColor = vec4(velocity, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const pressureShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      varying highp vec2 vL;
+      varying highp vec2 vR;
+      varying highp vec2 vT;
+      varying highp vec2 vB;
+      uniform sampler2D uPressure;
+      uniform sampler2D uDivergence;
+
+      void main () {
+          float L = texture2D(uPressure, vL).x;
+          float R = texture2D(uPressure, vR).x;
+          float T = texture2D(uPressure, vT).x;
+          float B = texture2D(uPressure, vB).x;
+          float C = texture2D(uPressure, vUv).x;
+          float divergence = texture2D(uDivergence, vUv).x;
+          float pressure = (L + R + B + T - divergence) * 0.25;
+          gl_FragColor = vec4(pressure, 0.0, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const gradientSubtractShader = compileShader(
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      precision mediump sampler2D;
+      varying highp vec2 vUv;
+      varying highp vec2 vL;
+      varying highp vec2 vR;
+      varying highp vec2 vT;
+      varying highp vec2 vB;
+      uniform sampler2D uPressure;
+      uniform sampler2D uVelocity;
+
+      void main () {
+          float L = texture2D(uPressure, vL).x;
+          float R = texture2D(uPressure, vR).x;
+          float T = texture2D(uPressure, vT).x;
+          float B = texture2D(uPressure, vB).x;
+          vec2 velocity = texture2D(uVelocity, vUv).xy;
+          velocity.xy -= vec2(R - L, T - B);
+          gl_FragColor = vec4(velocity, 0.0, 1.0);
+      }
+    `,
+    );
+
+    const blit = (() => {
+      const buffer = gl.createBuffer()!;
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([-1, -1, -1, 1, 1, 1, 1, -1]),
+        gl.STATIC_DRAW,
+      );
+      const elemBuffer = gl.createBuffer()!;
+      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, elemBuffer);
+      gl.bufferData(
+        gl.ELEMENT_ARRAY_BUFFER,
+        new Uint16Array([0, 1, 2, 0, 2, 3]),
+        gl.STATIC_DRAW,
+      );
+      gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+      gl.enableVertexAttribArray(0);
+
+      return (target: FBO | null, doClear = false) => {
+        if (!gl) return;
+        if (!target) {
+          gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+          gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        } else {
+          gl.viewport(0, 0, target.width, target.height);
+          gl.bindFramebuffer(gl.FRAMEBUFFER, target.fbo);
+        }
+        if (doClear) {
+          gl.clearColor(0, 0, 0, 1);
+          gl.clear(gl.COLOR_BUFFER_BIT);
+        }
+        gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+      };
+    })();
+
+    interface FBO {
+      texture: WebGLTexture;
+      fbo: WebGLFramebuffer;
+      width: number;
+      height: number;
+      texelSizeX: number;
+      texelSizeY: number;
+      attach: (id: number) => number;
+    }
+
+    interface DoubleFBO {
+      width: number;
+      height: number;
+      texelSizeX: number;
+      texelSizeY: number;
+      read: FBO;
+      write: FBO;
+      swap: () => void;
+    }
+
+    let dye: DoubleFBO;
+    let velocity: DoubleFBO;
+    let divergence: FBO;
+    let curl: FBO;
+    let pressure: DoubleFBO;
+
+    const copyProgram = new Program(baseVertexShader, copyShader);
+    const clearProgram = new Program(baseVertexShader, clearShader);
+    const splatProgram = new Program(baseVertexShader, splatShader);
+    const advectionProgram = new Program(baseVertexShader, advectionShader);
+    const divergenceProgram = new Program(baseVertexShader, divergenceShader);
+    const curlProgram = new Program(baseVertexShader, curlShader);
+    const vorticityProgram = new Program(baseVertexShader, vorticityShader);
+    const pressureProgram = new Program(baseVertexShader, pressureShader);
+    const gradienSubtractProgram = new Program(baseVertexShader, gradientSubtractShader);
+    const displayMaterial = new Material(baseVertexShader, displayShaderSource);
+
+    function createFBO(
+      w: number,
+      h: number,
+      internalFormat: number,
+      format: number,
+      type: number,
+      param: number,
+    ): FBO {
+      gl.activeTexture(gl.TEXTURE0);
+      const texture = gl.createTexture()!;
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, param);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, param);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, w, h, 0, format, type, null);
+      const fbo = gl.createFramebuffer()!;
+      gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+      gl.framebufferTexture2D(
+        gl.FRAMEBUFFER,
+        gl.COLOR_ATTACHMENT0,
+        gl.TEXTURE_2D,
+        texture,
+        0,
+      );
+      gl.viewport(0, 0, w, h);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      const texelSizeX = 1 / w;
+      const texelSizeY = 1 / h;
+
+      return {
+        texture,
+        fbo,
+        width: w,
+        height: h,
+        texelSizeX,
+        texelSizeY,
+        attach(id: number) {
+          gl.activeTexture(gl.TEXTURE0 + id);
+          gl.bindTexture(gl.TEXTURE_2D, texture);
+          return id;
+        },
+      };
+    }
+
+    function createDoubleFBO(
+      w: number,
+      h: number,
+      internalFormat: number,
+      format: number,
+      type: number,
+      param: number,
+    ): DoubleFBO {
+      const fbo1 = createFBO(w, h, internalFormat, format, type, param);
+      const fbo2 = createFBO(w, h, internalFormat, format, type, param);
+      return {
+        width: w,
+        height: h,
+        texelSizeX: fbo1.texelSizeX,
+        texelSizeY: fbo1.texelSizeY,
+        read: fbo1,
+        write: fbo2,
+        swap() {
+          const tmp = this.read;
+          this.read = this.write;
+          this.write = tmp;
+        },
+      };
+    }
+
+    function resizeFBO(
+      target: FBO,
+      w: number,
+      h: number,
+      internalFormat: number,
+      format: number,
+      type: number,
+      param: number,
+    ) {
+      const newFBO = createFBO(w, h, internalFormat, format, type, param);
+      copyProgram.bind();
+      if (copyProgram.uniforms.uTexture)
+        gl.uniform1i(copyProgram.uniforms.uTexture, target.attach(0));
+      blit(newFBO, false);
+      return newFBO;
+    }
+
+    function resizeDoubleFBO(
+      target: DoubleFBO,
+      w: number,
+      h: number,
+      internalFormat: number,
+      format: number,
+      type: number,
+      param: number,
+    ) {
+      if (target.width === w && target.height === h) return target;
+      target.read = resizeFBO(target.read, w, h, internalFormat, format, type, param);
+      target.write = createFBO(w, h, internalFormat, format, type, param);
+      target.width = w;
+      target.height = h;
+      target.texelSizeX = 1 / w;
+      target.texelSizeY = 1 / h;
+      return target;
+    }
+
+    function initFramebuffers() {
+      const simRes = getResolution(config.SIM_RESOLUTION!);
+      const dyeRes = getResolution(config.DYE_RESOLUTION!);
+
+      const texType = ext.halfFloatTexType;
+      const rgba = ext.formatRGBA;
+      const rg = ext.formatRG;
+      const r = ext.formatR;
+      const filtering = ext.supportLinearFiltering ? gl.LINEAR : gl.NEAREST;
+      gl.disable(gl.BLEND);
+
+      if (!dye) {
+        dye = createDoubleFBO(
+          dyeRes.width,
+          dyeRes.height,
+          rgba.internalFormat,
+          rgba.format,
+          texType,
+          filtering,
+        );
+      } else {
+        dye = resizeDoubleFBO(
+          dye,
+          dyeRes.width,
+          dyeRes.height,
+          rgba.internalFormat,
+          rgba.format,
+          texType,
+          filtering,
+        );
+      }
+
+      if (!velocity) {
+        velocity = createDoubleFBO(
+          simRes.width,
+          simRes.height,
+          rg.internalFormat,
+          rg.format,
+          texType,
+          filtering,
+        );
+      } else {
+        velocity = resizeDoubleFBO(
+          velocity,
+          simRes.width,
+          simRes.height,
+          rg.internalFormat,
+          rg.format,
+          texType,
+          filtering,
+        );
+      }
+
+      divergence = createFBO(
+        simRes.width,
+        simRes.height,
+        r.internalFormat,
+        r.format,
+        texType,
+        gl.NEAREST,
+      );
+      curl = createFBO(
+        simRes.width,
+        simRes.height,
+        r.internalFormat,
+        r.format,
+        texType,
+        gl.NEAREST,
+      );
+      pressure = createDoubleFBO(
+        simRes.width,
+        simRes.height,
+        r.internalFormat,
+        r.format,
+        texType,
+        gl.NEAREST,
+      );
+    }
+
+    function updateKeywords() {
+      const displayKeywords: string[] = [];
+      if (config.SHADING) displayKeywords.push('SHADING');
+      displayMaterial.setKeywords(displayKeywords);
+    }
+
+    function getResolution(resolution: number) {
+      const w = gl.drawingBufferWidth;
+      const h = gl.drawingBufferHeight;
+      const aspectRatio = w / h;
+      const aspect = aspectRatio < 1 ? 1 / aspectRatio : aspectRatio;
+      const min = Math.round(resolution);
+      const max = Math.round(resolution * aspect);
+      if (w > h) {
+        return { width: max, height: min };
+      }
+      return { width: min, height: max };
+    }
+
+    function scaleByPixelRatio(input: number) {
+      const pixelRatio = window.devicePixelRatio || 1;
+      return Math.floor(input * pixelRatio);
+    }
+
+    updateKeywords();
+    initFramebuffers();
+
+    let lastUpdateTime = Date.now();
+    let colorUpdateTimer = 0.0;
+    let animationFrameId: number | null = null;
+    let isAnimating = false;
+
+    function updateFrame() {
+      const dt = calcDeltaTime();
+      if (resizeCanvas()) initFramebuffers();
+      updateColors(dt);
+      applyInputs();
+      step(dt);
+      render(null);
+      animationFrameId = requestAnimationFrame(updateFrame);
+    }
+
+    function startAnimation() {
+      if (isAnimating) return;
+
+      isAnimating = true;
+      updateFrame();
+    }
+
+    function calcDeltaTime() {
+      const now = Date.now();
+      let dt = (now - lastUpdateTime) / 1000;
+      dt = Math.min(dt, 0.016666);
+      lastUpdateTime = now;
+      return dt;
+    }
+
+    function resizeCanvas() {
+      const width = scaleByPixelRatio(canvas!.clientWidth);
+      const height = scaleByPixelRatio(canvas!.clientHeight);
+      if (canvas!.width !== width || canvas!.height !== height) {
+        canvas!.width = width;
+        canvas!.height = height;
+        return true;
+      }
+      return false;
+    }
+
+    function updateColors(dt: number) {
+      colorUpdateTimer += dt * config.COLOR_UPDATE_SPEED;
+      if (colorUpdateTimer >= 1) {
+        colorUpdateTimer = wrap(colorUpdateTimer, 0, 1);
+        pointers.forEach(p => {
+          p.color = generateColor();
+        });
+      }
+    }
+
+    function applyInputs() {
+      for (const p of pointers) {
+        if (p.moved) {
+          p.moved = false;
+          splatPointer(p);
+        }
+      }
+    }
+
+    function step(dt: number) {
+      gl.disable(gl.BLEND);
+
+      curlProgram.bind();
+      if (curlProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          curlProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (curlProgram.uniforms.uVelocity) {
+        gl.uniform1i(curlProgram.uniforms.uVelocity, velocity.read.attach(0));
+      }
+      blit(curl);
+
+      vorticityProgram.bind();
+      if (vorticityProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          vorticityProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (vorticityProgram.uniforms.uVelocity) {
+        gl.uniform1i(vorticityProgram.uniforms.uVelocity, velocity.read.attach(0));
+      }
+      if (vorticityProgram.uniforms.uCurl) {
+        gl.uniform1i(vorticityProgram.uniforms.uCurl, curl.attach(1));
+      }
+      if (vorticityProgram.uniforms.curl) {
+        gl.uniform1f(vorticityProgram.uniforms.curl, config.CURL);
+      }
+      if (vorticityProgram.uniforms.dt) {
+        gl.uniform1f(vorticityProgram.uniforms.dt, dt);
+      }
+      blit(velocity.write);
+      velocity.swap();
+
+      divergenceProgram.bind();
+      if (divergenceProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          divergenceProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (divergenceProgram.uniforms.uVelocity) {
+        gl.uniform1i(divergenceProgram.uniforms.uVelocity, velocity.read.attach(0));
+      }
+      blit(divergence);
+
+      clearProgram.bind();
+      if (clearProgram.uniforms.uTexture) {
+        gl.uniform1i(clearProgram.uniforms.uTexture, pressure.read.attach(0));
+      }
+      if (clearProgram.uniforms.value) {
+        gl.uniform1f(clearProgram.uniforms.value, config.PRESSURE);
+      }
+      blit(pressure.write);
+      pressure.swap();
+
+      pressureProgram.bind();
+      if (pressureProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          pressureProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (pressureProgram.uniforms.uDivergence) {
+        gl.uniform1i(pressureProgram.uniforms.uDivergence, divergence.attach(0));
+      }
+      for (let i = 0; i < config.PRESSURE_ITERATIONS; i++) {
+        if (pressureProgram.uniforms.uPressure) {
+          gl.uniform1i(pressureProgram.uniforms.uPressure, pressure.read.attach(1));
+        }
+        blit(pressure.write);
+        pressure.swap();
+      }
+
+      gradienSubtractProgram.bind();
+      if (gradienSubtractProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          gradienSubtractProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (gradienSubtractProgram.uniforms.uPressure) {
+        gl.uniform1i(gradienSubtractProgram.uniforms.uPressure, pressure.read.attach(0));
+      }
+      if (gradienSubtractProgram.uniforms.uVelocity) {
+        gl.uniform1i(gradienSubtractProgram.uniforms.uVelocity, velocity.read.attach(1));
+      }
+      blit(velocity.write);
+      velocity.swap();
+
+      advectionProgram.bind();
+      if (advectionProgram.uniforms.texelSize) {
+        gl.uniform2f(
+          advectionProgram.uniforms.texelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
+        gl.uniform2f(
+          advectionProgram.uniforms.dyeTexelSize,
+          velocity.texelSizeX,
+          velocity.texelSizeY,
+        );
+      }
+      const velocityId = velocity.read.attach(0);
+      if (advectionProgram.uniforms.uVelocity) {
+        gl.uniform1i(advectionProgram.uniforms.uVelocity, velocityId);
+      }
+      if (advectionProgram.uniforms.uSource) {
+        gl.uniform1i(advectionProgram.uniforms.uSource, velocityId);
+      }
+      if (advectionProgram.uniforms.dt) {
+        gl.uniform1f(advectionProgram.uniforms.dt, dt);
+      }
+      if (advectionProgram.uniforms.dissipation) {
+        gl.uniform1f(advectionProgram.uniforms.dissipation, config.VELOCITY_DISSIPATION);
+      }
+      blit(velocity.write);
+      velocity.swap();
+
+      if (!ext.supportLinearFiltering && advectionProgram.uniforms.dyeTexelSize) {
+        gl.uniform2f(
+          advectionProgram.uniforms.dyeTexelSize,
+          dye.texelSizeX,
+          dye.texelSizeY,
+        );
+      }
+      if (advectionProgram.uniforms.uVelocity) {
+        gl.uniform1i(advectionProgram.uniforms.uVelocity, velocity.read.attach(0));
+      }
+      if (advectionProgram.uniforms.uSource) {
+        gl.uniform1i(advectionProgram.uniforms.uSource, dye.read.attach(1));
+      }
+      if (advectionProgram.uniforms.dissipation) {
+        gl.uniform1f(advectionProgram.uniforms.dissipation, config.DENSITY_DISSIPATION);
+      }
+      blit(dye.write);
+      dye.swap();
+    }
+
+    function render(target: FBO | null) {
+      gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+      gl.enable(gl.BLEND);
+      drawDisplay(target);
+    }
+
+    function drawDisplay(target: FBO | null) {
+      const width = target ? target.width : gl.drawingBufferWidth;
+      const height = target ? target.height : gl.drawingBufferHeight;
+      displayMaterial.bind();
+      if (config.SHADING && displayMaterial.uniforms.texelSize) {
+        gl.uniform2f(displayMaterial.uniforms.texelSize, 1 / width, 1 / height);
+      }
+      if (displayMaterial.uniforms.uTexture) {
+        gl.uniform1i(displayMaterial.uniforms.uTexture, dye.read.attach(0));
+      }
+      blit(target, false);
+    }
+
+    function splatPointer(pointer: Pointer) {
+      const dx = pointer.deltaX * config.SPLAT_FORCE;
+      const dy = pointer.deltaY * config.SPLAT_FORCE;
+      splat(pointer.texcoordX, pointer.texcoordY, dx, dy, pointer.color);
+    }
+
+    function clickSplat(pointer: Pointer) {
+      const color = generateColor();
+      color.r *= 10;
+      color.g *= 10;
+      color.b *= 10;
+      const dx = 10 * (Math.random() - 0.5);
+      const dy = 30 * (Math.random() - 0.5);
+      splat(pointer.texcoordX, pointer.texcoordY, dx, dy, color);
+    }
+
+    function splat(x: number, y: number, dx: number, dy: number, color: ColorRGB) {
+      splatProgram.bind();
+      if (splatProgram.uniforms.uTarget) {
+        gl.uniform1i(splatProgram.uniforms.uTarget, velocity.read.attach(0));
+      }
+      if (splatProgram.uniforms.aspectRatio) {
+        gl.uniform1f(splatProgram.uniforms.aspectRatio, canvas!.width / canvas!.height);
+      }
+      if (splatProgram.uniforms.point) {
+        gl.uniform2f(splatProgram.uniforms.point, x, y);
+      }
+      if (splatProgram.uniforms.color) {
+        gl.uniform3f(splatProgram.uniforms.color, dx, dy, 0);
+      }
+      if (splatProgram.uniforms.radius) {
+        gl.uniform1f(
+          splatProgram.uniforms.radius,
+          correctRadius(config.SPLAT_RADIUS / 100)!,
+        );
+      }
+      blit(velocity.write);
+      velocity.swap();
+
+      if (splatProgram.uniforms.uTarget) {
+        gl.uniform1i(splatProgram.uniforms.uTarget, dye.read.attach(0));
+      }
+      if (splatProgram.uniforms.color) {
+        gl.uniform3f(splatProgram.uniforms.color, color.r, color.g, color.b);
+      }
+      blit(dye.write);
+      dye.swap();
+    }
+
+    function correctRadius(radius: number) {
+      const aspectRatio = canvas!.width / canvas!.height;
+      return aspectRatio > 1 ? radius * aspectRatio : radius;
+    }
+
+    function updatePointerDownData(
+      pointer: Pointer,
+      id: number,
+      posX: number,
+      posY: number,
+    ) {
+      pointer.id = id;
+      pointer.down = true;
+      pointer.moved = false;
+      pointer.texcoordX = posX / canvas!.width;
+      pointer.texcoordY = 1 - posY / canvas!.height;
+      pointer.prevTexcoordX = pointer.texcoordX;
+      pointer.prevTexcoordY = pointer.texcoordY;
+      pointer.deltaX = 0;
+      pointer.deltaY = 0;
+      pointer.color = generateColor();
+    }
+
+    function updatePointerMoveData(
+      pointer: Pointer,
+      posX: number,
+      posY: number,
+      color: ColorRGB,
+    ) {
+      pointer.prevTexcoordX = pointer.texcoordX;
+      pointer.prevTexcoordY = pointer.texcoordY;
+      pointer.texcoordX = posX / canvas!.width;
+      pointer.texcoordY = 1 - posY / canvas!.height;
+      pointer.deltaX = correctDeltaX(pointer.texcoordX - pointer.prevTexcoordX)!;
+      pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY)!;
+      pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;
+      pointer.color = color;
+    }
+
+    function updatePointerUpData(pointer: Pointer) {
+      pointer.down = false;
+    }
+
+    function correctDeltaX(delta: number) {
+      const aspectRatio = canvas!.width / canvas!.height;
+      return aspectRatio < 1 ? delta * aspectRatio : delta;
+    }
+
+    function correctDeltaY(delta: number) {
+      const aspectRatio = canvas!.width / canvas!.height;
+      return aspectRatio > 1 ? delta / aspectRatio : delta;
+    }
+
+    function hexToRGB(hex: string): ColorRGB {
+      let val = hex.replace('#', '');
+      if (val.length === 3) val = val[0] + val[0] + val[1] + val[1] + val[2] + val[2];
+      const r = parseInt(val.slice(0, 2), 16) / 255;
+      const g = parseInt(val.slice(2, 4), 16) / 255;
+      const b = parseInt(val.slice(4, 6), 16) / 255;
+      return { r: r * 0.15, g: g * 0.15, b: b * 0.15 };
+    }
+
+    function generateColor(): ColorRGB {
+      if (!config.RAINBOW_MODE) {
+        return hexToRGB(config.COLOR!);
+      }
+      const c = HSVtoRGB(Math.random(), 1.0, 1.0);
+      c.r *= 0.15;
+      c.g *= 0.15;
+      c.b *= 0.15;
+      return c;
+    }
+
+    function HSVtoRGB(h: number, s: number, v: number): ColorRGB {
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      const i = Math.floor(h * 6);
+      const f = h * 6 - i;
+      const p = v * (1 - s);
+      const q = v * (1 - f * s);
+      const t = v * (1 - (1 - f) * s);
+
+      switch (i % 6) {
+        case 0:
+          r = v;
+          g = t;
+          b = p;
+          break;
+        case 1:
+          r = q;
+          g = v;
+          b = p;
+          break;
+        case 2:
+          r = p;
+          g = v;
+          b = t;
+          break;
+        case 3:
+          r = p;
+          g = q;
+          b = v;
+          break;
+        case 4:
+          r = t;
+          g = p;
+          b = v;
+          break;
+        case 5:
+          r = v;
+          g = p;
+          b = q;
+          break;
+        default:
+          break;
+      }
+      return { r, g, b };
+    }
+
+    function wrap(value: number, min: number, max: number) {
+      const range = max - min;
+      if (range === 0) return min;
+      return ((value - min) % range) + min;
+    }
+
+    window.addEventListener(
+      'mousedown',
+      e => {
+        const pointer = pointers[0];
+        const posX = scaleByPixelRatio(e.clientX);
+        const posY = scaleByPixelRatio(e.clientY);
+        updatePointerDownData(pointer, -1, posX, posY);
+        clickSplat(pointer);
+      },
+      { signal },
+    );
+
+    function handleFirstMouseMove(e: MouseEvent) {
+      const pointer = pointers[0];
+      const posX = scaleByPixelRatio(e.clientX);
+      const posY = scaleByPixelRatio(e.clientY);
+      const color = generateColor();
+      startAnimation();
+      updatePointerMoveData(pointer, posX, posY, color);
+      document.body.removeEventListener('mousemove', handleFirstMouseMove);
+    }
+    document.body.addEventListener('mousemove', handleFirstMouseMove, { signal });
+
+    window.addEventListener(
+      'mousemove',
+      e => {
+        const pointer = pointers[0];
+        const posX = scaleByPixelRatio(e.clientX);
+        const posY = scaleByPixelRatio(e.clientY);
+        updatePointerMoveData(pointer, posX, posY, pointer.color);
+      },
+      { signal },
+    );
+
+    function handleFirstTouchStart(e: TouchEvent) {
+      const touches = e.targetTouches;
+      const pointer = pointers[0];
+      startAnimation();
+      for (let i = 0; i < touches.length; i++) {
+        const posX = scaleByPixelRatio(touches[i].clientX);
+        const posY = scaleByPixelRatio(touches[i].clientY);
+        updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+      }
+      document.body.removeEventListener('touchstart', handleFirstTouchStart);
+    }
+    document.body.addEventListener('touchstart', handleFirstTouchStart, { signal });
+
+    window.addEventListener(
+      'touchstart',
+      e => {
+        const touches = e.targetTouches;
+        const pointer = pointers[0];
+        for (let i = 0; i < touches.length; i++) {
+          const posX = scaleByPixelRatio(touches[i].clientX);
+          const posY = scaleByPixelRatio(touches[i].clientY);
+          updatePointerDownData(pointer, touches[i].identifier, posX, posY);
+        }
+      },
+      { signal },
+    );
+
+    window.addEventListener(
+      'touchmove',
+      e => {
+        const touches = e.targetTouches;
+        const pointer = pointers[0];
+        for (let i = 0; i < touches.length; i++) {
+          const posX = scaleByPixelRatio(touches[i].clientX);
+          const posY = scaleByPixelRatio(touches[i].clientY);
+          updatePointerMoveData(pointer, posX, posY, pointer.color);
+        }
+      },
+      { signal },
+    );
+
+    window.addEventListener(
+      'touchend',
+      e => {
+        const touches = e.changedTouches;
+        const pointer = pointers[0];
+        for (let i = 0; i < touches.length; i++) {
+          updatePointerUpData(pointer);
+        }
+      },
+      { signal },
+    );
+
+    return () => {
+      abortController.abort();
+      isAnimating = false;
+
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [
+    SIM_RESOLUTION,
+    DYE_RESOLUTION,
+    CAPTURE_RESOLUTION,
+    DENSITY_DISSIPATION,
+    VELOCITY_DISSIPATION,
+    PRESSURE,
+    PRESSURE_ITERATIONS,
+    CURL,
+    SPLAT_RADIUS,
+    SPLAT_FORCE,
+    SHADING,
+    COLOR_UPDATE_SPEED,
+    BACK_COLOR,
+    TRANSPARENT,
+    RAINBOW_MODE,
+    COLOR,
+  ]);
+
+  return (
+    <div {...props}>
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/packages/react-kit/src/components/index.test.ts
+++ b/packages/react-kit/src/components/index.test.ts
@@ -7,7 +7,7 @@
 // --------------------------------------------------------------------------------
 
 import { assert, describe, it } from 'vitest';
-import { SVGWrapper, Typewriter } from './index.js';
+import { CursorSplash, SVGWrapper, Typewriter } from './index.js';
 
 // --------------------------------------------------------------------------------
 // Test
@@ -15,6 +15,11 @@ import { SVGWrapper, Typewriter } from './index.js';
 
 describe('index', () => {
   describe('exports', () => {
+    it('`CursorSplash` should be defined', () => {
+      assert.isDefined(CursorSplash);
+      assert.strictEqual(typeof CursorSplash, 'function');
+    });
+
     it('`SVGWrapper` should be defined', () => {
       assert.isDefined(SVGWrapper);
       assert.strictEqual(typeof SVGWrapper, 'function');

--- a/packages/react-kit/src/components/index.ts
+++ b/packages/react-kit/src/components/index.ts
@@ -1,2 +1,3 @@
+export * from './cursor-splash.js';
 export * from './svg-wrapper.js';
 export * from './typewriter.js';


### PR DESCRIPTION
This pull request introduces a new cursor splash visual effect to the blog app and adds comprehensive tests and type checks for the `CursorSplash` component in the shared `react-kit` package. The splash effect is conditionally rendered based on user device and preferences, and is styled by the consumer. Additionally, a minor color value adjustment is made for the dark theme background.

**New Cursor Splash Feature Integration:**

* Added a new `CursorSplash` component to the blog layout, which displays a cursor splash effect only on devices that support hover, have a fine pointer, and do not prefer reduced motion (`apps/blog/src/app/[lang]/layout.tsx`, `apps/blog/src/components/cursor-splash.tsx`, `apps/blog/src/components/cursor-splash.module.css`). ([apps/blog/src/app/[lang]/layout.tsxR15](diffhunk://#diff-717ba665b14d2804de1ff8e57585a90f3d1c553ade376158f686841624ad59e5R15), [apps/blog/src/app/[lang]/layout.tsxR84](diffhunk://#diff-717ba665b14d2804de1ff8e57585a90f3d1c553ade376158f686841624ad59e5R84), [[1]](diffhunk://#diff-32cf7ac61a93813f3491a452dac180c16dfbf048d69711bcf460d11748546bcbR1-R64) [[2]](diffhunk://#diff-632cd2b9798d2088c92a318a4ab166f5d43c4d62d69c2d76e0d012a93f132bdbR1-R16)
* The `CursorSplash` component is imported from the shared `@lumir/react-kit/components` package and styled with a local CSS module. [[1]](diffhunk://#diff-32cf7ac61a93813f3491a452dac180c16dfbf048d69711bcf460d11748546bcbR1-R64) [[2]](diffhunk://#diff-632cd2b9798d2088c92a318a4ab166f5d43c4d62d69c2d76e0d012a93f132bdbR1-R16)

**Component Library Improvements:**

* Exported `CursorSplash` from the shared `react-kit` package, making it available for use in other projects (`packages/react-kit/src/components/index.ts`).
* Added tests to ensure `CursorSplash` is correctly exported and behaves as expected (`packages/react-kit/src/components/index.test.ts`, `packages/react-kit/src/components/cursor-splash.test.tsx`). [[1]](diffhunk://#diff-b2acbec4157efa5f3a1bb56107c7ac08203252392802a9e6ae28ce880ec51559L10-R22) [[2]](diffhunk://#diff-2f23ad001363fa63635168218cf4cd88da51d3d6cabcf95f06f91e61fb710238R1-R35)
* Added a TypeScript type test file for `CursorSplash` to verify prop types and usage (`packages/react-kit/src/components/cursor-splash.test-d.tsx`).

**Visual/Styling Adjustment:**

* Updated the dark theme background color variable for `--color-bg-inset` to a slightly different shade (`apps/blog/src/styles/variables.css`).