### PR TITLE
refactor(*): inline shared CSS utilities and update `styles/variables.css`

### DIFF
--- a/apps/blog/src/components/aside/categories.module.css
+++ b/apps/blog/src/components/aside/categories.module.css
@@ -1,9 +1,13 @@
 .react-icons {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .count-docs {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .categories {
@@ -56,6 +60,9 @@
       grid-area: 1 / 3 / 3 / 4;
 
       & > span {
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: var(--size-20);
         height: var(--size-20);
         font-size: var(--font-size-xs);

--- a/apps/blog/src/components/aside/categories.tsx
+++ b/apps/blog/src/components/aside/categories.tsx
@@ -48,9 +48,7 @@ export async function Categories({ lang }: PropsWithLang) {
               <div className={styles['name-en']}>{en}</div>
               <div className={styles['name-ko']}>{ko}</div>
               <div className={styles['count-docs']}>
-                <span className="flex-center">
-                  {markdownCollection.byLangCategory[lang][categoryKey].length}
-                </span>
+                <span>{markdownCollection.byLangCategory[lang][categoryKey].length}</span>
                 <FaPen />
               </div>
             </Link>

--- a/apps/blog/src/components/aside/links.module.css
+++ b/apps/blog/src/components/aside/links.module.css
@@ -1,10 +1,15 @@
 .links {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: var(--spacing-static-sm) 0 var(--spacing-static-md);
   list-style: none;
 
   & > li > a {
+    display: flex;
     flex-direction: column;
+    align-items: center;
+    justify-content: center;
     padding: var(--size-6);
 
     & > * {
@@ -25,6 +30,9 @@
     }
 
     & > span {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       width: var(--size-40);
       color: var(--color-fg-muted);
       letter-spacing: var(--letter-spacing-tighter);

--- a/apps/blog/src/components/aside/links.tsx
+++ b/apps/blog/src/components/aside/links.tsx
@@ -14,7 +14,6 @@ import 'server-only';
 
 import Link from 'next/link';
 import { FaGithub, FaHouseChimney } from '@lumir/react-kit/svgs';
-import { cn } from '@lumir/utils';
 import { author } from '@/data/author';
 import { type PropsWithLang } from '@/data/lang';
 import styles from './links.module.css';
@@ -27,18 +26,15 @@ export function Links({ lang }: PropsWithLang) {
   return (
     <ul className={styles.links}>
       <li>
-        <Link className={cn('flex-center', 'custom-hover-effect')} href={`/${lang}`}>
+        <Link className="custom-hover-effect" href={`/${lang}`}>
           <FaHouseChimney />
-          <span className="flex-center">Home</span>
+          <span>Home</span>
         </Link>
       </li>
       <li>
-        <Link
-          className={cn('flex-center', 'custom-hover-effect')}
-          href={author.lumirlumir.htmlUrl}
-        >
+        <Link className="custom-hover-effect" href={author.lumirlumir.htmlUrl}>
           <FaGithub />
-          <span className="flex-center">GitHub</span>
+          <span>GitHub</span>
         </Link>
       </li>
     </ul>

--- a/apps/blog/src/components/aside/profile.module.css
+++ b/apps/blog/src/components/aside/profile.module.css
@@ -1,6 +1,8 @@
 .profile {
-  composes: flex-center from global;
+  display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   margin: var(--spacing-static-md);
 
   & > img {

--- a/apps/blog/src/components/header/doc-search.module.css
+++ b/apps/blog/src/components/header/doc-search.module.css
@@ -1,5 +1,7 @@
 .doc-search {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   margin: var(--size-10) var(--spacing-static-sm) var(--size-10) 0;
 
   @media (width >= 768px) {

--- a/apps/blog/src/components/nav/sort.module.css
+++ b/apps/blog/src/components/nav/sort.module.css
@@ -1,9 +1,13 @@
 .react-icons {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .sort {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .list {

--- a/apps/blog/src/styles/index.css
+++ b/apps/blog/src/styles/index.css
@@ -1,7 +1,6 @@
 /* External */
 @import '@lumir/styles/normalize.css';
 @import '@lumir/styles/animations.css';
-@import '@lumir/styles/utilities.css';
 @import '@lumir/styles/variables.css';
 @import 'katex/dist/katex.min.css';
 

--- a/apps/moing/src/app.css
+++ b/apps/moing/src/app.css
@@ -33,6 +33,9 @@ body,
   }
 
   & > main {
+    display: flex;
     grid-area: 1 / 2 / 4 / 3;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/apps/moing/src/app.tsx
+++ b/apps/moing/src/app.tsx
@@ -14,7 +14,6 @@ import {
   GrPowerReset,
   IoIosCheckmarkCircleOutline,
 } from '@lumir/react-kit/svgs';
-import { cn } from '@lumir/utils';
 
 import Button from '@/components/button';
 import Client from '@/components/client';
@@ -84,9 +83,9 @@ export default function App() {
         }}
       />
 
-      <Timer currentCount={currentCount} />
+      <Timer className="timer" currentCount={currentCount} />
 
-      <main className={cn('flex-center', 'custom-scrollbar')}>
+      <main className="custom-scrollbar">
         <div ref={scrollRef}>
           <Title />
           <Server

--- a/apps/moing/src/components/button.module.css
+++ b/apps/moing/src/components/button.module.css
@@ -1,0 +1,5 @@
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/apps/moing/src/components/button.module.css
+++ b/apps/moing/src/components/button.module.css
@@ -2,4 +2,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: var(--transition);
 }

--- a/apps/moing/src/components/button.tsx
+++ b/apps/moing/src/components/button.tsx
@@ -13,6 +13,8 @@ import NeonButton from '@/components/neon-button';
 import NeonFont from '@/components/neon-font';
 import { useScenarioContext } from '@/contexts/scenario-context';
 
+import styles from './button.module.css';
+
 // --------------------------------------------------------------------------------
 // Typedef
 // --------------------------------------------------------------------------------
@@ -41,7 +43,7 @@ export default function Button({ type, icon, onClick, hoverEffect = false }: Pro
     <div
       className={cn(
         `${type}`,
-        'flex-center',
+        styles.button,
         'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
         status === 'visible' && 'pointer-events-none',

--- a/apps/moing/src/components/button.tsx
+++ b/apps/moing/src/components/button.tsx
@@ -44,7 +44,6 @@ export default function Button({ type, icon, onClick, hoverEffect = false }: Pro
       className={cn(
         `${type}`,
         styles.button,
-        'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
         status === 'visible' && 'pointer-events-none',
       )}

--- a/apps/moing/src/components/client.module.css
+++ b/apps/moing/src/components/client.module.css
@@ -1,5 +1,6 @@
 .client {
   height: var(--main-section-height);
+  transition: var(--transition);
 
   & > div {
     width: 100%;

--- a/apps/moing/src/components/client.tsx
+++ b/apps/moing/src/components/client.tsx
@@ -27,7 +27,6 @@ export default function Client() {
     <NeonDiv
       className={cn(
         styles.client,
-        'transition',
         'custom-scrollbar',
         'custom-main-section',
         'custom-main-section-bash',

--- a/apps/moing/src/components/config.module.css
+++ b/apps/moing/src/components/config.module.css
@@ -3,6 +3,7 @@
   align-items: center;
   justify-content: center;
   height: calc(var(--main-section-height) * 1.5);
+  transition: var(--transition);
 
   & > div {
     letter-spacing: 4px;

--- a/apps/moing/src/components/config.module.css
+++ b/apps/moing/src/components/config.module.css
@@ -1,5 +1,7 @@
 .config {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: calc(var(--main-section-height) * 1.5);
 
   & > div {

--- a/apps/moing/src/components/config.tsx
+++ b/apps/moing/src/components/config.tsx
@@ -98,7 +98,6 @@ export default function Config() {
         styles.config,
         'custom-scrollbar',
         'custom-main-section',
-        'transition',
         'select-none',
         config.visibility || 'custom-invisible-section',
       )}

--- a/apps/moing/src/components/main-button.module.css
+++ b/apps/moing/src/components/main-button.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: var(--transition);
   animation:
     4s ease-in-out 4s backwards global(fade-in),
     8s ease-in-out pointer-events-none;

--- a/apps/moing/src/components/main-button.module.css
+++ b/apps/moing/src/components/main-button.module.css
@@ -1,5 +1,7 @@
 .main-button {
-  composes: flex-center from global;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   animation:
     4s ease-in-out 4s backwards global(fade-in),
     8s ease-in-out pointer-events-none;

--- a/apps/moing/src/components/main-button.tsx
+++ b/apps/moing/src/components/main-button.tsx
@@ -49,7 +49,6 @@ export default function ButtonMain() {
       className={cn(
         styles['main-button'],
         'custom-main-others',
-        'transition',
         (isLastSection() && isConfigDone()) || status !== 'hidden'
           ? ''
           : 'pointer-events-none opacity-0',

--- a/apps/moing/src/components/server.module.css
+++ b/apps/moing/src/components/server.module.css
@@ -1,5 +1,6 @@
 .server {
   height: var(--main-section-height);
+  transition: var(--transition);
 
   &.wide {
     height: 600px;

--- a/apps/moing/src/components/server.tsx
+++ b/apps/moing/src/components/server.tsx
@@ -84,7 +84,6 @@ export default function Server({ onTestWriteComplete }: ServerProps) {
         'custom-scrollbar',
         'custom-main-section',
         'custom-main-section-bash',
-        'transition',
         status !== 'hidden' && !config.visibility ? '' : 'custom-invisible-section',
         mode === 'result' && styles.wide,
       )}

--- a/apps/moing/src/components/timer.module.css
+++ b/apps/moing/src/components/timer.module.css
@@ -1,0 +1,5 @@
+.timer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/apps/moing/src/components/timer.module.css
+++ b/apps/moing/src/components/timer.module.css
@@ -2,4 +2,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: var(--transition);
 }

--- a/apps/moing/src/components/timer.tsx
+++ b/apps/moing/src/components/timer.tsx
@@ -47,7 +47,6 @@ export default function Timer({ className = '', currentCount }: TimerProps) {
       className={cn(
         styles.timer,
         className,
-        'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
       )}
     >

--- a/apps/moing/src/components/timer.tsx
+++ b/apps/moing/src/components/timer.tsx
@@ -9,6 +9,7 @@
 import { cn } from '@lumir/utils';
 import NeonFont from '@/components/neon-font';
 import { useScenarioContext } from '@/contexts/scenario-context';
+import styles from './timer.module.css';
 
 // --------------------------------------------------------------------------------
 // Typedef
@@ -19,6 +20,12 @@ import { useScenarioContext } from '@/contexts/scenario-context';
  */
 interface TimerProps {
   /**
+   * CSS class name for the timer component.
+   * @default ''
+   */
+  className?: string;
+
+  /**
    * Current count of the timer in milliseconds.
    */
   currentCount: number;
@@ -28,7 +35,7 @@ interface TimerProps {
 // Export
 // --------------------------------------------------------------------------------
 
-export default function Timer({ currentCount }: TimerProps) {
+export default function Timer({ className = '', currentCount }: TimerProps) {
   const { section } = useScenarioContext();
   const { status } = section.timer;
   const remainingSeconds = Math.ceil(currentCount / 1_000);
@@ -38,8 +45,8 @@ export default function Timer({ currentCount }: TimerProps) {
   return (
     <footer
       className={cn(
-        'timer',
-        'flex-center',
+        styles.timer,
+        className,
         'transition',
         status === 'hidden' && 'pointer-events-none opacity-0',
       )}

--- a/apps/moing/src/components/title.module.css
+++ b/apps/moing/src/components/title.module.css
@@ -3,6 +3,7 @@
   top: 0;
   z-index: 100;
   pointer-events: none;
+  transition: var(--transition);
 
   & h1 {
     margin: 0;

--- a/apps/moing/src/components/title.tsx
+++ b/apps/moing/src/components/title.tsx
@@ -25,7 +25,6 @@ export default function Title() {
     <div
       className={cn(
         styles.title,
-        'transition',
         'select-none',
         'custom-main-others',
         status === 'hidden' && 'pointer-events-none opacity-0',

--- a/apps/moing/src/styles/index.css
+++ b/apps/moing/src/styles/index.css
@@ -1,7 +1,6 @@
 /* External */
 @import '@lumir/styles/normalize.css';
 @import '@lumir/styles/animations.css';
-@import '@lumir/styles/utilities.css';
 @import '@lumir/styles/variables.css';
 
 /* Internal */

--- a/apps/moing/src/styles/utilities.css
+++ b/apps/moing/src/styles/utilities.css
@@ -43,11 +43,6 @@
   opacity: 0;
 }
 
-/* Transitions & Animation: https://tailwindcss.com/docs/transition-property */
-.transition {
-  transition: all 2s ease-in-out;
-}
-
 /* Interactivity: https://tailwindcss.com/docs/pointer-events */
 .pointer-events-none {
   pointer-events: none;

--- a/apps/moing/src/styles/variables.css
+++ b/apps/moing/src/styles/variables.css
@@ -16,4 +16,5 @@
   --main-section-width: 620px;
   --main-section-height: max(150px, 20vh);
   --main-section-padding: 40px;
+  --transition: all 2s ease-in-out;
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -6,7 +6,6 @@
   "exports": {
     "./animations.css": "./src/animations.css",
     "./normalize.css": "./src/normalize.css",
-    "./utilities.css": "./src/utilities.css",
     "./variables.css": "./src/variables.css",
     "./package.json": "./package.json"
   },

--- a/packages/styles/src/utilities.css
+++ b/packages/styles/src/utilities.css
@@ -1,5 +1,0 @@
-.flex-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/packages/styles/src/variables.css
+++ b/packages/styles/src/variables.css
@@ -31,8 +31,13 @@
   --border-radius-md: var(--size-6);
   --border-radius-xl: var(--size-12);
   --border-radius-circle: 50%;
+  --border-radius-pill: 999px;
 
   /* spacing */
+  --spacing-fluid-xs: clamp(var(--size-4), calc(0.25vw + var(--size-2)), var(--size-8));
+  --spacing-fluid-sm: clamp(var(--size-8), calc(0.5vw + var(--size-4)), var(--size-16));
+  --spacing-fluid-md: clamp(var(--size-16), calc(1.25vw + var(--size-8)), var(--size-32));
+
   --spacing-static-xs: var(--size-4);
   --spacing-static-sm: var(--size-8);
   --spacing-static-md: var(--size-16);
@@ -50,7 +55,12 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
 
+  --letter-spacing-widest: 0.1em;
+  --letter-spacing-wider: 0.05em;
+  --letter-spacing-wide: 0.025em;
+  --letter-spacing-normal: 0;
   --letter-spacing-tight: -0.025em;
   --letter-spacing-tighter: -0.05em;
   --letter-spacing-tightest: -0.075em;


### PR DESCRIPTION
This pull request refactors the codebase to remove the dependency on the global `flex-center` utility class by replacing it with explicit flexbox styling in component-level CSS modules. It also cleans up unused utility imports and updates component usage accordingly. Additionally, some transitions are moved from JSX class lists into CSS modules for better maintainability.

**Refactoring CSS for Flex Layouts:**
- Replaced `composes: flex-center from global;` with explicit `display: flex; align-items: center; justify-content: center;` in multiple CSS module files, including `categories.module.css`, `links.module.css`, `profile.module.css`, `doc-search.module.css`, `sort.module.css`, `config.module.css`, and `main-button.module.css`. [[1]](diffhunk://#diff-d0f6796c30ddc210e9ea302465078fa6a07fbab3504a6a5c3dd6e007eb602f7bL2-R10) [[2]](diffhunk://#diff-9be6889cf14cadac346a120b07f5a6aa9a9448529c50fa5f67185faefb91a999L2-R12) [[3]](diffhunk://#diff-9c06a0c0cf75346070fdf3b1e7dac7aa45b070ff5646db3e6dfdf47e320e6a00L2-R5) [[4]](diffhunk://#diff-923a18f246881360c0a94026179405ff3cfb9ccd39a85139d709df4baa9b7214L2-R4) [[5]](diffhunk://#diff-7ed938d067722c716d1e63de23239b911e555d59400b44c00666a8698640971cL2-R10) [[6]](diffhunk://#diff-bcf0960211a7c10cc35f294b00d1ec56ca1dce98c1d9574a41145c8caeb998e9L2-R6) [[7]](diffhunk://#diff-7c6609bd9f958b3dfef59a8eae680f82641d0c49d7f1c4f25a5b52c59293b4ceL2-R5)
- Added new `.button` class with flexbox styling and transition to `button.module.css`, updating the `Button` component to use it. [[1]](diffhunk://#diff-30672f904971ffb51b182956414d3200b0db954bb8274eb5fc87cc83915cf67eR1-R6) [[2]](diffhunk://#diff-92f7eb504e321c09279d1fa0bb759ea09a5f57ddbbcaa8710ca7a6f17cbb670eR16-R17) [[3]](diffhunk://#diff-92f7eb504e321c09279d1fa0bb759ea09a5f57ddbbcaa8710ca7a6f17cbb670eL44-R46)

**Component and Utility Cleanup:**
- Removed usage and import of the `flex-center` utility and the `@lumir/styles/utilities.css` global stylesheet. [[1]](diffhunk://#diff-6960b1a8a9e41809a5b71616ba46c1fd3deba56bc13db75bd349537af041ce62L4) [[2]](diffhunk://#diff-f2f4c03f5e98f25ddaac41ac773c877f205a8675f28cdf19024529ddaa92b9aeL17) [[3]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbL17)
- Updated components to no longer apply the `flex-center` class via `cn()` or as a className, and removed related code in `categories.tsx`, `links.tsx`, and `app.tsx`. [[1]](diffhunk://#diff-dfe3b1759f7a2daa3c5c3e2b31aa81882f17d2020531f0b49e14893b29110566L51-R51) [[2]](diffhunk://#diff-f2f4c03f5e98f25ddaac41ac773c877f205a8675f28cdf19024529ddaa92b9aeL30-R37) [[3]](diffhunk://#diff-81b3d6778b0db5eedf67eb3bf6f9d4f313ee58f417996466d8e0a90ed0113bbbL87-R88)

**Transition Handling Improvements:**
- Moved transition styles from component class lists in JSX into their respective CSS modules for `client`, `config`, `main-button`, and `server` components. [[1]](diffhunk://#diff-80f5d089f66abebb65f6a866f3bc71a0df9e7be8360ddc285613a892183370ffR3) [[2]](diffhunk://#diff-bcf0960211a7c10cc35f294b00d1ec56ca1dce98c1d9574a41145c8caeb998e9L2-R6) [[3]](diffhunk://#diff-7c6609bd9f958b3dfef59a8eae680f82641d0c49d7f1c4f25a5b52c59293b4ceL2-R5) [[4]](diffhunk://#diff-528ce7748c5db09ad985a5d7031e60bd1c20d239b69fb5e2744de4871f1fcfbcR3) [[5]](diffhunk://#diff-1a9a5213c4217a3b65da476ac856b20b5fb5e07030b44d967759380a57507bd3L30) [[6]](diffhunk://#diff-5fedca8790c3aeebba62bfcbe2d3a6a18a4592f5383e9e3c7a14c06f7c85dbb4L101) [[7]](diffhunk://#diff-8873f66b1b50d3c3aa9f8d7cb1402f3cf15694abcc84a54b70b101ac100a9ec4L52) [[8]](diffhunk://#diff-41c1cd58a532fe061a794859eb646a71407e7f69f21ca71b7f8298b6cb691e3aL87)

**Minor Layout and Style Adjustments:**
- Ensured inner elements (e.g., `span` in `categories.module.css` and `links.module.css`) are also flex containers for proper alignment. [[1]](diffhunk://#diff-d0f6796c30ddc210e9ea302465078fa6a07fbab3504a6a5c3dd6e007eb602f7bR63-R65) [[2]](diffhunk://#diff-9be6889cf14cadac346a120b07f5a6aa9a9448529c50fa5f67185faefb91a999R33-R35)
- Updated `apps/moing/src/app.css` to explicitly set flex layout and centering for the `main` element.