### PR TITLE
refactor(blog): centralize theme configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Before any Next.js work, find and read the relevant doc in `node_modules/next/di
 
 - In a fresh clone, run `git pull -p` from the repo root before `npm install` to pull the latest branch state and prune stale remote-tracking branches.
 - Then run `npm install` from the repo root before attempting tests, builds, lint, or package changes.
-- Before running browser tests, run `npx playwright install chromium --with-deps --only-shell` from the repo root.
+- Before running browser tests, check whether the Chromium shell required by the currently installed Playwright version is already installed. Only when it is not installed, run `npx playwright install chromium --with-deps --only-shell` from the repo root.
 - Do not start validation or implementation work until the install has completed successfully, because the workspace dependencies are required across the monorepo.
 
 ## Test/Build/Lint Workflow (required before finalizing)

--- a/apps/blog/src/components/theme-context.tsx
+++ b/apps/blog/src/components/theme-context.tsx
@@ -24,16 +24,11 @@ import {
   useSyncExternalStore,
   type PropsWithChildren,
 } from 'react';
+import { themeDefault, themeKey, themeKeys, type Theme } from '@/data/theme';
 
 // --------------------------------------------------------------------------------
 // Typedef
 // --------------------------------------------------------------------------------
-
-/**
- * Represents the available application theme modes.
- * @default 'dark'
- */
-export type Theme = 'dark' | 'light';
 
 /**
  * Defines the shape of the context value provided by the `ThemeContext`,
@@ -45,16 +40,14 @@ export type ThemeContextValue = readonly [theme: Theme, toggleTheme: () => void]
 // Helper
 // --------------------------------------------------------------------------------
 
-const themeKey = 'data-theme';
-const defaultTheme = 'dark' satisfies Theme;
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 function getThemeSnapshot(): Theme {
-  return (document.documentElement.getAttribute(themeKey) ?? defaultTheme) as Theme;
+  return (document.documentElement.getAttribute(themeKey) ?? themeDefault) as Theme;
 }
 
-function getServerThemeSnapshot(): typeof defaultTheme {
-  return defaultTheme;
+function getServerThemeSnapshot(): typeof themeDefault {
+  return themeDefault;
 }
 
 function subscribeThemeStore(onStoreChange: () => void): () => void {
@@ -71,7 +64,7 @@ function subscribeThemeStore(onStoreChange: () => void): () => void {
 }
 
 function toggleTheme() {
-  const nextTheme = getThemeSnapshot() === 'dark' ? 'light' : 'dark';
+  const nextTheme = getThemeSnapshot() === themeKeys[0] ? themeKeys[1] : themeKeys[0];
 
   // 1. Update the `data-theme` attribute on the root document element to apply the theme globally.
   document.documentElement.setAttribute(themeKey, nextTheme);

--- a/apps/blog/src/components/theme-script.tsx
+++ b/apps/blog/src/components/theme-script.tsx
@@ -3,6 +3,12 @@
  */
 
 // --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { themeKey, themeKeys } from '@/data/theme';
+
+// --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
@@ -31,12 +37,8 @@
  */
 export function ThemeScript() {
   return (
-    <script
-      // eslint-disable-next-line react/no-danger -- Safe because the script is hardcoded and does not include any user input.
-      dangerouslySetInnerHTML={{
-        __html:
-          "document.documentElement.setAttribute('data-theme', localStorage.getItem('data-theme') ?? (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'));",
-      }}
-    />
+    <script>
+      {`document.documentElement.setAttribute('${themeKey}', localStorage.getItem('${themeKey}') ?? (matchMedia('(prefers-color-scheme: ${themeKeys[1]})').matches ? '${themeKeys[1]}' : '${themeKeys[0]}'));`}
+    </script>
   );
 }

--- a/apps/blog/src/components/theme-toggle.tsx
+++ b/apps/blog/src/components/theme-toggle.tsx
@@ -19,8 +19,9 @@ import 'client-only';
 // --------------------------------------------------------------------------------
 
 import { cn } from '@lumir/utils';
-import { useThemeContext, type Theme } from '@/components/theme-context';
+import { useThemeContext } from '@/components/theme-context';
 import { type LangRecord, type PropsWithLang } from '@/data/lang';
+import { themeDefault, type Theme } from '@/data/theme';
 import styles from './theme-toggle.module.css';
 
 // --------------------------------------------------------------------------------
@@ -58,7 +59,7 @@ export function ThemeToggle({ lang }: PropsWithLang) {
         type="button"
         onClick={toggleTheme}
         aria-label={dictionary[lang].ariaLabel[theme]}
-        aria-pressed={theme === 'dark'}
+        aria-pressed={theme === themeDefault}
       >
         <span className={styles.orb} aria-hidden="true" />
         <span className={styles.shadow} aria-hidden="true" />

--- a/apps/blog/src/data/theme.ts
+++ b/apps/blog/src/data/theme.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Defines supported theme keys.
+ */
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Represents the supported application theme.
+ */
+export type Theme = (typeof themeKeys)[number];
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * The key used for the root document attribute and persisted theme preference.
+ */
+export const themeKey = 'data-theme';
+
+/**
+ * The default application theme.
+ */
+export const themeDefault = 'dark' as const satisfies Theme;
+
+/**
+ * Supported application themes.
+ */
+export const themeKeys = ['dark', 'light'] as const;


### PR DESCRIPTION
This pull request refactors theme management in the blog app to centralize theme constants and types in a new `theme.ts` data module. It updates all theme-related logic and components to use these shared values, improving maintainability and consistency. There are also minor improvements to the Playwright test instructions.

**Theme management refactor:**

* Introduced a new `apps/blog/src/data/theme.ts` module that exports `themeKey`, `themeDefault`, `themeKeys`, and the `Theme` type, centralizing all theme-related constants and types.
* Updated `theme-context.tsx`, `theme-toggle.tsx`, and `theme-script.tsx` to import and use the shared theme constants and types from `theme.ts` instead of local definitions. This ensures consistent theme handling across components and reduces duplication. [[1]](diffhunk://#diff-38879c1d96005c595e18c1b867820d16ad311daf685f14cd1333111104d35d4dR27-L37) [[2]](diffhunk://#diff-38879c1d96005c595e18c1b867820d16ad311daf685f14cd1333111104d35d4dL48-R50) [[3]](diffhunk://#diff-38879c1d96005c595e18c1b867820d16ad311daf685f14cd1333111104d35d4dL74-R67) [[4]](diffhunk://#diff-e710aba6c92cf03789cf43e6ef2a860b75e2d0cced506ef5b9445a1dbe8e5003L22-R24) [[5]](diffhunk://#diff-e710aba6c92cf03789cf43e6ef2a860b75e2d0cced506ef5b9445a1dbe8e5003L61-R62) [[6]](diffhunk://#diff-577ed6f978000cbf4921aed222ebc68500aa5ecf907fade5cdea70ab74bcea97R5-R10) [[7]](diffhunk://#diff-577ed6f978000cbf4921aed222ebc68500aa5ecf907fade5cdea70ab74bcea97L34-R42)

**Test instructions improvement:**

* Updated the Playwright browser test instructions in `AGENTS.md` to recommend checking if the Chromium shell is already installed before running the install command, making the setup process more efficient.