### PR TITLE
feat(@lumir/react-kit): add `use-shortcut` hook

### DIFF
--- a/apps/blog/playwright.config.js
+++ b/apps/blog/playwright.config.js
@@ -31,7 +31,7 @@ export default defineConfig({
       ],
   retries: isCI ? 1 : 0,
   testDir: './tests',
-  workers: '75%',
+  workers: isCI ? '75%' : 1,
 
   projects: [
     {

--- a/apps/blog/src/components/lang-toggle.tsx
+++ b/apps/blog/src/components/lang-toggle.tsx
@@ -19,6 +19,8 @@ import 'client-only';
 // --------------------------------------------------------------------------------
 
 import { useSelectedLayoutSegments } from 'next/navigation';
+import { useRef } from 'react';
+import { useShortcut } from '@lumir/react-kit/hooks';
 import { langDefault, langKeys, type LangRecord, type PropsWithLang } from '@/data/lang';
 import styles from './lang-toggle.module.css';
 
@@ -40,9 +42,14 @@ const dictionary = {
 // --------------------------------------------------------------------------------
 
 export function LangToggle({ lang }: PropsWithLang) {
+  const anchorRef = useRef<HTMLAnchorElement>(null);
   const layoutSegments = useSelectedLayoutSegments();
   const nextLang = langKeys.find(langkey => langkey !== lang) ?? langDefault;
   const href = `/${[nextLang, ...layoutSegments].join('/')}` as const;
+
+  useShortcut('l', () => {
+    anchorRef.current?.click();
+  });
 
   return (
     <div className={styles['lang-toggle']}>
@@ -52,6 +59,7 @@ export function LangToggle({ lang }: PropsWithLang) {
        * also reruns `ThemeScript` before hydration to restore the persisted `data-theme` safely.
        */}
       <a
+        ref={anchorRef}
         className="custom-hover-effect"
         href={href}
         onClick={e => {

--- a/apps/blog/src/components/theme-toggle.tsx
+++ b/apps/blog/src/components/theme-toggle.tsx
@@ -18,6 +18,7 @@ import 'client-only';
 // Import
 // --------------------------------------------------------------------------------
 
+import { useShortcut } from '@lumir/react-kit/hooks';
 import { cn } from '@lumir/utils';
 import { useThemeContext } from '@/contexts/theme';
 import { type LangRecord, type PropsWithLang } from '@/data/lang';
@@ -52,6 +53,8 @@ const dictionary = {
  */
 export function ThemeToggle({ lang }: PropsWithLang) {
   const [theme, toggleTheme] = useThemeContext();
+
+  useShortcut('t', toggleTheme);
 
   return (
     <div className={styles['theme-toggle']}>

--- a/apps/blog/tests/keyboard-shortcut.test.ts
+++ b/apps/blog/tests/keyboard-shortcut.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview End-to-end tests for keyboard shortcuts.
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { expect, test } from '@playwright/test';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+test.describe('keyboard-shortcut', () => {
+  test('Dispatched `L` keydown should switch the current page to the other language', async ({
+    page,
+  }) => {
+    await page.goto('/ko/posts/everything-about-markdown', {
+      waitUntil: 'networkidle',
+    });
+
+    await page.evaluate(() => {
+      dispatchEvent(new KeyboardEvent('keydown', { key: 'l' }));
+    });
+
+    await expect(page).toHaveURL(/\/en\/posts\/everything-about-markdown$/);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+  });
+
+  test('Dispatched `T` keydown should toggle the current theme', async ({ page }) => {
+    await page.goto('/ko/posts/everything-about-markdown', {
+      waitUntil: 'networkidle',
+    });
+
+    await page.evaluate(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      localStorage.setItem('data-theme', 'dark');
+    });
+
+    await page.evaluate(() => {
+      dispatchEvent(new KeyboardEvent('keydown', { key: 't' }));
+    });
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    expect(await page.evaluate(() => localStorage.getItem('data-theme'))).toBe('light');
+  });
+});

--- a/apps/blog/tests/no-javascript.test.ts
+++ b/apps/blog/tests/no-javascript.test.ts
@@ -18,7 +18,7 @@ test.use({ javaScriptEnabled: false });
 // Test
 // --------------------------------------------------------------------------------
 
-test.describe('pages rendered without JavaScript', () => {
+test.describe('no-javascript', () => {
   test.describe('posts', () => {
     test('Korean post route should render its semantic HTML and heading', async ({
       page,

--- a/packages/react-kit/src/hooks/index.test.ts
+++ b/packages/react-kit/src/hooks/index.test.ts
@@ -14,6 +14,7 @@ import {
   usePrevious,
   usePreviousDistinct,
   useScroll,
+  useShortcut,
   useSpeechRecognition,
   useToggle,
   useTypewriter,
@@ -53,6 +54,11 @@ describe('index', () => {
     it('`useScroll` should be defined', () => {
       assert.isDefined(useScroll);
       assert.strictEqual(typeof useScroll, 'function');
+    });
+
+    it('`useShortcut` should be defined', () => {
+      assert.isDefined(useShortcut);
+      assert.strictEqual(typeof useShortcut, 'function');
     });
 
     it('`useSpeechRecognition` should be defined', () => {

--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -4,6 +4,7 @@ export * from './use-isomorphic-layout-effect.js';
 export * from './use-previous.js';
 export * from './use-previous-distinct.js';
 export * from './use-scroll.js';
+export * from './use-shortcut.js';
 export * from './use-speech-recognition.js';
 export * from './use-toggle.js';
 export * from './use-typewriter.js';

--- a/packages/react-kit/src/hooks/use-shortcut.test-d.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.test-d.ts
@@ -6,16 +6,40 @@
 // Import
 // --------------------------------------------------------------------------------
 
-import { useShortcut } from './use-shortcut.js';
+import { useShortcut, type UseShortcutOptions } from './use-shortcut.js';
 
 // --------------------------------------------------------------------------------
 // Test
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------
+// #region UseShortcutOptions
+
+let options: UseShortcutOptions;
+
+options = {};
+options = { ctrlKey: true };
+options = { metaKey: true };
+options = { ctrlKey: true, metaKey: false };
+
+// @ts-expect-error - `ctrlKey` should be a boolean.
+options = { ctrlKey: 'true' };
+// @ts-expect-error - `metaKey` should be a boolean.
+options = { metaKey: 'true' };
+// @ts-expect-error - `unknown` is not a valid property of `UseShortcutOptions`.
+options = { unknown: true };
+
+// #endregion UseShortcutOptions
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
 // #region useShortcut
 
-({}) as typeof useShortcut satisfies (key: string, callback: () => void) => void;
+({}) as typeof useShortcut satisfies (
+  key: string,
+  callback: () => void,
+  options?: UseShortcutOptions,
+) => void;
 
 // @ts-expect-error - `useShortcut` should be a function.
 ({}) as typeof useShortcut satisfies boolean;
@@ -25,6 +49,10 @@ import { useShortcut } from './use-shortcut.js';
 function useShortcutTypeTest() {
   useShortcut('k', () => undefined);
   useShortcut('Enter', () => undefined);
+  useShortcut('k', () => undefined, {});
+  useShortcut('k', () => undefined, { ctrlKey: true });
+  useShortcut('k', () => undefined, { metaKey: true });
+  useShortcut('k', () => undefined, { ctrlKey: true, metaKey: false });
 
   // @ts-expect-error - `key` should be a string.
   useShortcut(1, () => undefined);
@@ -32,8 +60,10 @@ function useShortcutTypeTest() {
   useShortcut('k', (value: string) => value);
   // @ts-expect-error - `callback` is required.
   useShortcut('k');
-  // @ts-expect-error - `useShortcut` accepts only two arguments.
+  // @ts-expect-error - `options` should be an object.
   useShortcut('k', () => undefined, true);
+  // @ts-expect-error - `useShortcut` accepts only three arguments.
+  useShortcut('k', () => undefined, {}, true);
 }
 
 // #endregion useShortcut

--- a/packages/react-kit/src/hooks/use-shortcut.test-d.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.test-d.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Type test for `use-shortcut.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useShortcut } from './use-shortcut.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useShortcut
+
+({}) as typeof useShortcut satisfies (key: string, callback: () => void) => void;
+
+// @ts-expect-error - `useShortcut` should be a function.
+({}) as typeof useShortcut satisfies boolean;
+// @ts-expect-error - `useShortcut` should be a function.
+({}) as typeof useShortcut satisfies string;
+
+function useShortcutTypeTest() {
+  useShortcut('k', () => undefined);
+  useShortcut('Enter', () => undefined);
+
+  // @ts-expect-error - `key` should be a string.
+  useShortcut(1, () => undefined);
+  // @ts-expect-error - `callback` should be a function with no required arguments.
+  useShortcut('k', (value: string) => value);
+  // @ts-expect-error - `callback` is required.
+  useShortcut('k');
+  // @ts-expect-error - `useShortcut` accepts only two arguments.
+  useShortcut('k', () => undefined, true);
+}
+
+// #endregion useShortcut
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-shortcut.test.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.test.ts
@@ -73,6 +73,61 @@ describe('use-shortcut', () => {
     assert.strictEqual(callback.mock.calls.length, 0);
   });
 
+  it('Shortcut typed in a focused input should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+    const input = document.createElement('input');
+
+    document.body.append(input);
+    input.focus();
+    input.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'k' }));
+    input.remove();
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it('Shortcut typed in a focused textarea should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+    const textarea = document.createElement('textarea');
+
+    document.body.append(textarea);
+    textarea.focus();
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'k' }));
+    textarea.remove();
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it('Shortcut typed in a focused select should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+    const select = document.createElement('select');
+
+    document.body.append(select);
+    select.focus();
+    select.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'k' }));
+    select.remove();
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it('Shortcut typed in focused contenteditable content should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+    const contenteditable = document.createElement('div');
+
+    contenteditable.contentEditable = 'true';
+    document.body.append(contenteditable);
+    contenteditable.focus();
+    contenteditable.dispatchEvent(
+      new KeyboardEvent('keydown', { bubbles: true, key: 'k' }),
+    );
+    contenteditable.remove();
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
   it('Different key should not run the callback', async () => {
     const callback = vi.fn();
     await renderHook(() => useShortcut('k', callback));

--- a/packages/react-kit/src/hooks/use-shortcut.test.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.test.ts
@@ -20,7 +20,6 @@ describe('use-shortcut', () => {
 
     const event = new KeyboardEvent('keydown', {
       cancelable: true,
-      ctrlKey: true,
       key: 'k',
     });
 
@@ -33,43 +32,52 @@ describe('use-shortcut', () => {
     const callback = vi.fn();
     await renderHook(() => useShortcut('k', callback));
 
-    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'K' }));
+    dispatchEvent(new KeyboardEvent('keydown', { key: 'K' }));
 
     assert.strictEqual(callback.mock.calls.length, 1);
   });
 
-  it('Ctrl shortcut should run the callback', async () => {
+  it('Ctrl shortcut should run the callback when `ctrlKey` is true', async () => {
     const callback = vi.fn();
-    await renderHook(() => useShortcut('k', callback));
+    await renderHook(() => useShortcut('k', callback, { ctrlKey: true }));
 
     dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'k' }));
 
     assert.strictEqual(callback.mock.calls.length, 1);
   });
 
-  it('Command shortcut should run the callback', async () => {
+  it('Command shortcut should run the callback when `metaKey` is true', async () => {
     const callback = vi.fn();
-    await renderHook(() => useShortcut('k', callback));
+    await renderHook(() => useShortcut('k', callback, { metaKey: true }));
 
     dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
 
     assert.strictEqual(callback.mock.calls.length, 1);
   });
 
-  it('Matching key without Ctrl or Command should not run the callback', async () => {
+  it('Ctrl shortcut should not run the callback when `ctrlKey` uses its false default', async () => {
     const callback = vi.fn();
     await renderHook(() => useShortcut('k', callback));
 
-    dispatchEvent(new KeyboardEvent('keydown', { key: 'k' }));
+    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'k' }));
 
     assert.strictEqual(callback.mock.calls.length, 0);
   });
 
-  it('Different key with Ctrl should not run the callback', async () => {
+  it('Command shortcut should not run the callback when `metaKey` uses its false default', async () => {
     const callback = vi.fn();
     await renderHook(() => useShortcut('k', callback));
 
-    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'p' }));
+    dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it('Different key should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
 
     assert.strictEqual(callback.mock.calls.length, 0);
   });

--- a/packages/react-kit/src/hooks/use-shortcut.test.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Test for `use-shortcut.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { assert, describe, it, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { useShortcut } from './use-shortcut.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('use-shortcut', () => {
+  it('Matched shortcut should prevent the default action', async () => {
+    await renderHook(() => useShortcut('k', () => undefined));
+
+    const event = new KeyboardEvent('keydown', {
+      cancelable: true,
+      ctrlKey: true,
+      key: 'k',
+    });
+
+    dispatchEvent(event);
+
+    assert.strictEqual(event.defaultPrevented, true);
+  });
+
+  it('Shortcut key matching should be case-insensitive', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'K' }));
+
+    assert.strictEqual(callback.mock.calls.length, 1);
+  });
+
+  it('Ctrl shortcut should run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'k' }));
+
+    assert.strictEqual(callback.mock.calls.length, 1);
+  });
+
+  it('Command shortcut should run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+
+    assert.strictEqual(callback.mock.calls.length, 1);
+  });
+
+  it('Matching key without Ctrl or Command should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { key: 'k' }));
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+
+  it('Different key with Ctrl should not run the callback', async () => {
+    const callback = vi.fn();
+    await renderHook(() => useShortcut('k', callback));
+
+    dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'p' }));
+
+    assert.strictEqual(callback.mock.calls.length, 0);
+  });
+});

--- a/packages/react-kit/src/hooks/use-shortcut.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview `useShortcut` hook.
+ */
+
+// --------------------------------------------------------------------------------
+// Directive
+// --------------------------------------------------------------------------------
+
+'use client';
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useEffect } from 'react';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * React hook that runs a callback when a `Ctrl` or `Command` keyboard shortcut is pressed.
+ *
+ * Key matching is case-insensitive. When the shortcut matches, the browser's
+ * default action is prevented before the callback runs.
+ *
+ * @param key The key to combine with Ctrl or Command.
+ * @param callback The function to run when the shortcut is pressed.
+ *
+ * @example
+ * ```tsx
+ * import { useShortcut } from '@lumir/react-kit/hooks';
+ *
+ * function Component() {
+ *   useShortcut('k', () => {
+ *     console.log('Shortcut pressed');
+ *   });
+ *
+ *   return <div>Press Ctrl+K or Command+K</div>;
+ * }
+ * ```
+ */
+export function useShortcut(key: string, callback: () => void): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.key.toLowerCase() === key.toLowerCase()
+      ) {
+        event.preventDefault();
+        callback();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [key, callback]);
+}

--- a/packages/react-kit/src/hooks/use-shortcut.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.ts
@@ -43,7 +43,8 @@ export interface UseShortcutOptions {
  * React hook that runs a callback when a keyboard shortcut is pressed.
  *
  * Key matching is case-insensitive. When the shortcut matches, the browser's
- * default action is prevented before the callback runs.
+ * default action is prevented before the callback runs. Keyboard events from
+ * editable controls are ignored.
  *
  * @param key The shortcut key.
  * @param callback The function to run when the shortcut is pressed.
@@ -69,6 +70,15 @@ export function useShortcut(
 ): void {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        event.target instanceof HTMLSelectElement ||
+        (event.target instanceof HTMLElement && event.target.isContentEditable)
+      ) {
+        return;
+      }
+
       if (
         event.ctrlKey === ctrlKey &&
         event.metaKey === metaKey &&

--- a/packages/react-kit/src/hooks/use-shortcut.ts
+++ b/packages/react-kit/src/hooks/use-shortcut.ts
@@ -15,17 +15,39 @@
 import { useEffect } from 'react';
 
 // --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Modifier key states required by `useShortcut`.
+ */
+export interface UseShortcutOptions {
+  /**
+   * Whether the Ctrl key must be active.
+   * @default false
+   */
+  ctrlKey?: boolean;
+
+  /**
+   * Whether the Command key must be active.
+   * @default false
+   */
+  metaKey?: boolean;
+}
+
+// --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
 
 /**
- * React hook that runs a callback when a `Ctrl` or `Command` keyboard shortcut is pressed.
+ * React hook that runs a callback when a keyboard shortcut is pressed.
  *
  * Key matching is case-insensitive. When the shortcut matches, the browser's
  * default action is prevented before the callback runs.
  *
- * @param key The key to combine with Ctrl or Command.
+ * @param key The shortcut key.
  * @param callback The function to run when the shortcut is pressed.
+ * @param options Required Ctrl and Command key states. Both default to `false`.
  *
  * @example
  * ```tsx
@@ -34,17 +56,22 @@ import { useEffect } from 'react';
  * function Component() {
  *   useShortcut('k', () => {
  *     console.log('Shortcut pressed');
- *   });
+ *   }, { ctrlKey: true });
  *
- *   return <div>Press Ctrl+K or Command+K</div>;
+ *   return <div>Press Ctrl+K</div>;
  * }
  * ```
  */
-export function useShortcut(key: string, callback: () => void): void {
+export function useShortcut(
+  key: string,
+  callback: () => void,
+  { ctrlKey = false, metaKey = false }: UseShortcutOptions = {},
+): void {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
-        (event.ctrlKey || event.metaKey) &&
+        event.ctrlKey === ctrlKey &&
+        event.metaKey === metaKey &&
         event.key.toLowerCase() === key.toLowerCase()
       ) {
         event.preventDefault();
@@ -57,5 +84,5 @@ export function useShortcut(key: string, callback: () => void): void {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [key, callback]);
+  }, [ctrlKey, metaKey, key, callback]);
 }


### PR DESCRIPTION
This pull request introduces a new `useShortcut` React hook to the shared component library and integrates keyboard shortcuts for language and theme toggling in the blog app. It also adds comprehensive tests for these features, ensuring robust functionality and type safety.

**Keyboard Shortcut Hook and Integration**

* Added a new `useShortcut` hook to `@lumir/react-kit/hooks`, allowing components to easily register keyboard shortcuts with optional Ctrl/Command modifiers. The hook is thoroughly documented and tested for both runtime and type correctness. [[1]](diffhunk://#diff-ca6d942b25689eb46127014921d6607677ca5d20c9c89250327866a0ae522dfbR1-R88) [[2]](diffhunk://#diff-af859dc6d76d78e0a86bc91354d90a7b0ff05aa083ed6526e4227d1beb950d81R1-R84) [[3]](diffhunk://#diff-d9f77a1cada540c02c06dff8ca004be12033ec879772d142dea329b4df9db784R1-R70) [[4]](diffhunk://#diff-f4432a733b5ee38515910032e2d4ee426fe5afaec1370104c68acb446d885706R7) [[5]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR17) [[6]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR59-R63)
* Integrated the `useShortcut` hook into the blog app:
  - Pressing `l` switches the language via the `LangToggle` component. [[1]](diffhunk://#diff-c5dae24c5cbd798e63cfd6bb6904526cb64d4efa006d0eb95b9794d9b5afe32aR22-R23) [[2]](diffhunk://#diff-c5dae24c5cbd798e63cfd6bb6904526cb64d4efa006d0eb95b9794d9b5afe32aR45-R53) [[3]](diffhunk://#diff-c5dae24c5cbd798e63cfd6bb6904526cb64d4efa006d0eb95b9794d9b5afe32aR62)
  - Pressing `t` toggles the theme via the `ThemeToggle` component. [[1]](diffhunk://#diff-e710aba6c92cf03789cf43e6ef2a860b75e2d0cced506ef5b9445a1dbe8e5003R21) [[2]](diffhunk://#diff-e710aba6c92cf03789cf43e6ef2a860b75e2d0cced506ef5b9445a1dbe8e5003R57-R58)

**End-to-End and Unit Testing**

* Added end-to-end Playwright tests to verify that the `l` and `t` shortcuts work as expected for language and theme switching.
* Updated and added unit and type tests for the new hook and its exports. [[1]](diffhunk://#diff-af859dc6d76d78e0a86bc91354d90a7b0ff05aa083ed6526e4227d1beb950d81R1-R84) [[2]](diffhunk://#diff-d9f77a1cada540c02c06dff8ca004be12033ec879772d142dea329b4df9db784R1-R70) [[3]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR17) [[4]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR59-R63) [[5]](diffhunk://#diff-f4432a733b5ee38515910032e2d4ee426fe5afaec1370104c68acb446d885706R7)

**Configuration and Minor Improvements**

* Updated Playwright test configuration to use a single worker locally for faster feedback while keeping parallelism in CI.
* Renamed a test suite for clarity.

These changes make keyboard navigation more accessible and improve test coverage and code maintainability.