### PR TITLE
refactor(blog): centralize frontmatter keys

### DIFF
--- a/apps/blog/src/data/frontmatter.tsx
+++ b/apps/blog/src/data/frontmatter.tsx
@@ -61,7 +61,7 @@ export interface Frontmatter {
 /**
  * Represents the key of the frontmatter defined in the `frontmatterMeta` object.
  */
-export type FrontmatterKey = keyof Frontmatter;
+export type FrontmatterKey = (typeof frontmatterKeys)[number];
 
 /**
  * Represents the keys of the frontmatter that can be sorted, excluding `description` and `categories` which are not typically used for sorting.
@@ -74,6 +74,15 @@ export type SortableFrontmatterKey = Exclude<
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------
+
+export const frontmatterKeys = [
+  'title',
+  'description',
+  'created',
+  'updated',
+  'categories',
+  'references',
+] as const satisfies readonly (keyof Frontmatter)[];
 
 /**
  * An object containing metadata for the frontmatter fields,


### PR DESCRIPTION
This pull request updates how frontmatter keys are defined and used in the `apps/blog/src/data/frontmatter.tsx` file. The main change is to explicitly declare the list of valid frontmatter keys in a new constant, and to update the `FrontmatterKey` type to reference this list, improving type safety and maintainability.

**Frontmatter key management:**

* Introduced a new `frontmatterKeys` constant that explicitly lists all valid frontmatter keys, ensuring a single source of truth for these keys.
* Updated the `FrontmatterKey` type to use the `frontmatterKeys` constant instead of `keyof Frontmatter`, making the type definition more robust and aligned with the explicit key list.