### PR TITLE
feat(@lumir/react-kit): add `use-os` hook

### DIFF
--- a/packages/react-kit/src/hooks/index.test.ts
+++ b/packages/react-kit/src/hooks/index.test.ts
@@ -11,6 +11,7 @@ import {
   useBooleanState,
   useCountdown,
   useIsomorphicLayoutEffect,
+  useOs,
   usePrevious,
   usePreviousDistinct,
   useScroll,
@@ -39,6 +40,11 @@ describe('index', () => {
     it('`useIsomorphicLayoutEffect` should be defined', () => {
       assert.isDefined(useIsomorphicLayoutEffect);
       assert.strictEqual(typeof useIsomorphicLayoutEffect, 'function');
+    });
+
+    it('`useOs` should be defined', () => {
+      assert.isDefined(useOs);
+      assert.strictEqual(typeof useOs, 'function');
     });
 
     it('`usePrevious` should be defined', () => {

--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './use-boolean-state.js';
 export * from './use-countdown.js';
 export * from './use-isomorphic-layout-effect.js';
+export * from './use-os.js';
 export * from './use-previous.js';
 export * from './use-previous-distinct.js';
 export * from './use-scroll.js';

--- a/packages/react-kit/src/hooks/use-os.test-d.ts
+++ b/packages/react-kit/src/hooks/use-os.test-d.ts
@@ -13,7 +13,7 @@ import { useOs, type UseOsReturn } from './use-os.js';
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------
-// #region UseOsReturnValue
+// #region UseOsReturn
 
 let os: UseOsReturn;
 
@@ -30,7 +30,7 @@ os = 'mac';
 // @ts-expect-error - `UseOsReturnValue` should be a string union.
 os = true;
 
-// #endregion UseOsReturnValue
+// #endregion UseOsReturn
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-os.test-d.ts
+++ b/packages/react-kit/src/hooks/use-os.test-d.ts
@@ -13,7 +13,7 @@ import { useOs, type UseOsReturn } from './use-os.js';
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------
-// #region UseOsReturnValue
+// #region UseOsReturn
 
 let os: UseOsReturn;
 
@@ -25,12 +25,12 @@ os = 'android';
 os = 'linux';
 os = 'chromeos';
 
-// @ts-expect-error - `mac` is not a valid `UseOsReturnValue`.
+// @ts-expect-error - `mac` is not a valid `UseOsReturn`.
 os = 'mac';
-// @ts-expect-error - `UseOsReturnValue` should be a string union.
+// @ts-expect-error - `UseOsReturn` should be a string union.
 os = true;
 
-// #endregion UseOsReturnValue
+// #endregion UseOsReturn
 // --------------------------------------------------------------------------------
 
 // --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-os.test-d.ts
+++ b/packages/react-kit/src/hooks/use-os.test-d.ts
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Type test for `use-os.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useOs, type UseOsReturn } from './use-os.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region UseOsReturnValue
+
+let os: UseOsReturn;
+
+os = 'undetermined';
+os = 'macos';
+os = 'ios';
+os = 'windows';
+os = 'android';
+os = 'linux';
+os = 'chromeos';
+
+// @ts-expect-error - `mac` is not a valid `UseOsReturnValue`.
+os = 'mac';
+// @ts-expect-error - `UseOsReturnValue` should be a string union.
+os = true;
+
+// #endregion UseOsReturnValue
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useOs
+
+({}) as typeof useOs satisfies () => UseOsReturn;
+({}) as ReturnType<typeof useOs> satisfies UseOsReturn;
+
+// @ts-expect-error - `useOs` should be a function.
+({}) as typeof useOs satisfies boolean;
+// @ts-expect-error - `useOs` should be a function.
+({}) as typeof useOs satisfies string;
+
+function useOsTypeTest() {
+  useOs();
+
+  const value = useOs();
+  value satisfies UseOsReturn;
+
+  // @ts-expect-error - `useOs` does not accept arguments.
+  useOs({});
+}
+
+// #endregion useOs
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-os.test.ts
+++ b/packages/react-kit/src/hooks/use-os.test.ts
@@ -17,6 +17,7 @@ import { useOs } from './use-os.js';
 describe('use-os', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    Reflect.deleteProperty(document, 'ontouchend');
   });
 
   it('`Macintosh` user agent should return `macos`', async () => {
@@ -97,8 +98,6 @@ describe('use-os', () => {
     const { result } = await renderHook(() => useOs());
 
     assert.strictEqual(result.current, 'ios');
-
-    Reflect.deleteProperty(document, 'ontouchend');
   });
 
   it('`Win32` user agent should return `windows`', async () => {

--- a/packages/react-kit/src/hooks/use-os.test.ts
+++ b/packages/react-kit/src/hooks/use-os.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview Test for `use-os.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { afterEach, assert, describe, it, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { useOs } from './use-os.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('use-os', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('`Macintosh` user agent should return `macos`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'macos');
+  });
+
+  it('`MacIntel` user agent should return `macos`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (MacIntel)',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'macos');
+  });
+
+  it('`MacPPC` user agent should return `macos`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (MacPPC)',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'macos');
+  });
+
+  it('`Mac68K` user agent should return `macos`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Mac68K)',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'macos');
+  });
+
+  it('`iPhone` user agent should return `ios`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'ios');
+  });
+
+  it('`iPad` user agent should return `ios`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (iPad)');
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'ios');
+  });
+
+  it('`iPod` user agent should return `ios`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (iPod)');
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'ios');
+  });
+
+  it('Touch-enabled `Macintosh` user agent should return `ios` for iPad desktop mode', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15',
+    );
+    Object.defineProperty(document, 'ontouchend', {
+      configurable: true,
+      value: null,
+    });
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'ios');
+
+    Reflect.deleteProperty(document, 'ontouchend');
+  });
+
+  it('`Win32` user agent should return `windows`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Win32)');
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'windows');
+  });
+
+  it('`Win64` user agent should return `windows`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Win64)');
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'windows');
+  });
+
+  it('`Windows` user agent should return `windows`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Windows NT 10.0; x64) AppleWebKit/537.36',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'windows');
+  });
+
+  it('`WinCE` user agent should return `windows`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (WinCE)');
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'windows');
+  });
+
+  it('Android user agent should return `android` before matching Linux', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'android');
+  });
+
+  it('ChromeOS user agent should return `chromeos`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (X11; CrOS x86_64 16093.68.0) AppleWebKit/537.36',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'chromeos');
+  });
+
+  it('Linux user agent should return `linux`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'linux');
+  });
+
+  it('Unknown user agent should return `undetermined`', async () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(
+      'Mozilla/5.0 (PlayStation 5 7.61) AppleWebKit/605.1.15',
+    );
+
+    const { result } = await renderHook(() => useOs());
+
+    assert.strictEqual(result.current, 'undetermined');
+  });
+});

--- a/packages/react-kit/src/hooks/use-os.ts
+++ b/packages/react-kit/src/hooks/use-os.ts
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview `useOs` hook.
+ * @see https://github.com/mantinedev/mantine/blob/master/packages/@mantine/hooks/src/use-os/use-os.ts
+ */
+
+// --------------------------------------------------------------------------------
+// Directive
+// --------------------------------------------------------------------------------
+
+'use client';
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useSyncExternalStore } from 'react';
+
+// --------------------------------------------------------------------------------
+// Typedef
+// --------------------------------------------------------------------------------
+
+/**
+ * Operating systems recognized by `useOs`.
+ */
+export type UseOsReturn =
+  'undetermined' | 'macos' | 'ios' | 'windows' | 'android' | 'linux' | 'chromeos';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+function isMacOs(userAgent: string) {
+  return /(?:Macintosh|MacIntel|MacPPC|Mac68K)/i.test(userAgent);
+}
+
+function isIos(userAgent: string) {
+  return /(?:iPhone|iPad|iPod)/i.test(userAgent);
+}
+
+function isWindows(userAgent: string) {
+  return /(?:Win32|Win64|Windows|WinCE)/i.test(userAgent);
+}
+
+function isAndroid(userAgent: string) {
+  return /Android/i.test(userAgent);
+}
+
+function isChromeOs(userAgent: string) {
+  return /CrOS/i.test(userAgent);
+}
+
+function isLinux(userAgent: string) {
+  return /Linux/i.test(userAgent);
+}
+
+function subscribeOs() {
+  return () => undefined;
+}
+
+function getOsSnapshot(): UseOsReturn {
+  const { userAgent } = window.navigator;
+
+  if (isIos(userAgent) || (isMacOs(userAgent) && 'ontouchend' in document)) {
+    return 'ios';
+  }
+
+  if (isMacOs(userAgent)) {
+    return 'macos';
+  }
+
+  if (isWindows(userAgent)) {
+    return 'windows';
+  }
+
+  if (isAndroid(userAgent)) {
+    return 'android';
+  }
+
+  if (isChromeOs(userAgent)) {
+    return 'chromeos';
+  }
+
+  if (isLinux(userAgent)) {
+    return 'linux';
+  }
+
+  return 'undetermined';
+}
+
+function getServerOsSnapshot(): UseOsReturn {
+  return 'undetermined';
+}
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * React hook that detects the user's operating system from the browser user agent.
+ *
+ * During server-side rendering, the hook returns `'undetermined'`. After hydration,
+ * it returns the client operating system. The operating system is treated as static
+ * for the lifetime of the page.
+ *
+ * @returns The detected operating system, or `'undetermined'` when it cannot be
+ * identified.
+ *
+ * @example
+ * ```tsx
+ * import { useOs } from '@lumir/react-kit/hooks';
+ *
+ * function Component() {
+ *   const os = useOs();
+ *   const modifierKey = os === 'macos' ? 'Command' : 'Ctrl';
+ *
+ *   return <kbd>{modifierKey} + K</kbd>;
+ * }
+ * ```
+ */
+export function useOs(): UseOsReturn {
+  return useSyncExternalStore(subscribeOs, getOsSnapshot, getServerOsSnapshot);
+}

--- a/packages/react-kit/vitest.config.js
+++ b/packages/react-kit/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
       enabled: true,
       headless: true,
       provider: playwright(),
+      screenshotFailures: false,
       instances: [{ browser: 'chromium' }],
     },
     include: ['src/**/*.test.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],


### PR DESCRIPTION
This pull request introduces a new `useOs` React hook to the `react-kit` package, which detects the user's operating system from the browser's user agent string. The hook is thoroughly tested, type-checked, and exported for public use. The PR also updates the test index and the Vitest configuration.

**New Feature: Operating System Detection Hook**
- Added a new `useOs` hook that determines the user's OS (e.g., `macos`, `ios`, `windows`, `android`, `linux`, `chromeos`, or `undetermined`) using the browser's user agent. The hook uses `useSyncExternalStore` for compatibility with React's concurrent features and returns `'undetermined'` during SSR.

**Testing and Type Safety**
- Added comprehensive runtime tests for `useOs`, covering all supported OS user agent strings and edge cases.
- Added TypeScript type tests to ensure the return type and API of `useOs` are correct and type-safe.

**Public API and Test Integration**
- Exported `useOs` and its types from the main hooks index, making it available for import from the package.
- Updated the hooks index test to assert that `useOs` is defined and is a function. [[1]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR14) [[2]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR45-R49)

**Test Runner Configuration**
- Updated Vitest configuration to disable screenshots on test failures for the Playwright provider.