### PR TITLE
feat(@lumir/react-kit): add `scroll-progress` hook

### DIFF
--- a/apps/blog/src/components/scroll-progress.module.css
+++ b/apps/blog/src/components/scroll-progress.module.css
@@ -9,10 +9,12 @@
 }
 
 .scroll-progress-bar {
+  --scroll-progress: 0;
+
   width: 100%;
   height: 100%;
   background-color: var(--color-fg-default);
-  transform: scaleX(0);
+  transform: scaleX(var(--scroll-progress));
   transform-origin: left center;
   will-change: transform;
 }

--- a/apps/blog/src/components/scroll-progress.tsx
+++ b/apps/blog/src/components/scroll-progress.tsx
@@ -18,7 +18,8 @@ import 'client-only';
 // Import
 // --------------------------------------------------------------------------------
 
-import { useEffect, useRef, type HTMLAttributes } from 'react';
+import { useRef, type HTMLAttributes } from 'react';
+import { useScrollProgress } from '@lumir/react-kit/hooks';
 import { cn } from '@lumir/utils';
 import styles from './scroll-progress.module.css';
 
@@ -41,42 +42,9 @@ export type ScrollProgressProps = HTMLAttributes<HTMLDivElement>;
 export function ScrollProgress({ className, ...props }: ScrollProgressProps) {
   const scrollProgressRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!scrollProgressRef.current) {
-      return undefined;
-    }
-
-    let rafId: number | null = null;
-
-    function requestProgressUpdate() {
-      if (!rafId) {
-        rafId = requestAnimationFrame(() => {
-          const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
-          const progress = maxScroll > 0 ? window.scrollY / maxScroll : 0;
-          const roundedProgress = Math.round(progress * 1000) / 1000;
-          const clampedProgress = Math.min(Math.max(roundedProgress, 0), 1);
-
-          scrollProgressRef.current!.style.transform = `scaleX(${clampedProgress})`;
-
-          rafId = null;
-        });
-      }
-    }
-
-    requestProgressUpdate();
-
-    window.addEventListener('scroll', requestProgressUpdate, { passive: true });
-    window.addEventListener('resize', requestProgressUpdate);
-
-    return () => {
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-
-      window.removeEventListener('scroll', requestProgressUpdate);
-      window.removeEventListener('resize', requestProgressUpdate);
-    };
-  }, []);
+  useScrollProgress(progress => {
+    scrollProgressRef.current?.style.setProperty('--scroll-progress', String(progress));
+  });
 
   return (
     <div className={cn(styles['scroll-progress'], className)} {...props}>

--- a/packages/react-kit/src/hooks/index.test.ts
+++ b/packages/react-kit/src/hooks/index.test.ts
@@ -15,6 +15,7 @@ import {
   usePrevious,
   usePreviousDistinct,
   useScroll,
+  useScrollProgress,
   useShortcut,
   useSpeechRecognition,
   useToggle,
@@ -60,6 +61,11 @@ describe('index', () => {
     it('`useScroll` should be defined', () => {
       assert.isDefined(useScroll);
       assert.strictEqual(typeof useScroll, 'function');
+    });
+
+    it('`useScrollProgress` should be defined', () => {
+      assert.isDefined(useScrollProgress);
+      assert.strictEqual(typeof useScrollProgress, 'function');
     });
 
     it('`useShortcut` should be defined', () => {

--- a/packages/react-kit/src/hooks/index.ts
+++ b/packages/react-kit/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from './use-os.js';
 export * from './use-previous.js';
 export * from './use-previous-distinct.js';
 export * from './use-scroll.js';
+export * from './use-scroll-progress.js';
 export * from './use-shortcut.js';
 export * from './use-speech-recognition.js';
 export * from './use-toggle.js';

--- a/packages/react-kit/src/hooks/use-scroll-progress.test-d.ts
+++ b/packages/react-kit/src/hooks/use-scroll-progress.test-d.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Type test for `use-scroll-progress.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useScrollProgress } from './use-scroll-progress.js';
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------------
+// #region useScrollProgress
+
+({}) as typeof useScrollProgress satisfies (
+  onProgress: (progress: number) => void,
+) => void;
+
+// @ts-expect-error - `useScrollProgress` should be a function.
+({}) as typeof useScrollProgress satisfies boolean;
+// @ts-expect-error - `useScrollProgress` should be a function.
+({}) as typeof useScrollProgress satisfies string;
+
+function useScrollProgressTypeTest() {
+  useScrollProgress(() => undefined);
+  useScrollProgress(progress => {
+    progress satisfies number;
+  });
+
+  // @ts-expect-error - `onProgress` is required.
+  useScrollProgress();
+  // @ts-expect-error - `onProgress` should be a function.
+  useScrollProgress(true);
+  // @ts-expect-error - `progress` should be a number.
+  useScrollProgress((progress: string) => progress);
+  // @ts-expect-error - `useScrollProgress` accepts only one argument.
+  useScrollProgress(() => undefined, {});
+}
+
+// #endregion useScrollProgress
+// --------------------------------------------------------------------------------

--- a/packages/react-kit/src/hooks/use-scroll-progress.test.ts
+++ b/packages/react-kit/src/hooks/use-scroll-progress.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @fileoverview Test for `use-scroll-progress.ts`
+ */
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { afterEach, assert, beforeEach, describe, it, vi } from 'vitest';
+import { renderHook } from 'vitest-browser-react';
+import { useScrollProgress } from './use-scroll-progress.js';
+
+// --------------------------------------------------------------------------------
+// Helper
+// --------------------------------------------------------------------------------
+
+/**
+ * `1000ms / 60fps ≈ 16.67ms` per frame, so we can use `16ms`
+ * as a close approximation for the duration of one animation frame.
+ */
+const RAF_FRAME_DURATION_MS = 16;
+
+// --------------------------------------------------------------------------------
+// Test
+// --------------------------------------------------------------------------------
+
+describe('use-scroll-progress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      now: 0,
+      toFake: ['requestAnimationFrame', 'cancelAnimationFrame'],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Initial animation frame should report the current normalized document scroll progress', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(250);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    assert.strictEqual(onProgress.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0.25]]);
+  });
+
+  it('Non-scrollable document should report zero progress', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(800);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(100);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0]]);
+  });
+
+  it('Reported progress should be rounded to three decimal places', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(123.456);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0.123]]);
+  });
+
+  it('Negative document scroll position should report zero progress', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(-100);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0]]);
+  });
+
+  it('Document scroll position beyond the maximum should report complete progress', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(1_100);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[1]]);
+  });
+
+  it('Multiple scroll events before the next animation frame should report progress once', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    const scrollY = vi.spyOn(window, 'scrollY', 'get').mockReturnValue(100);
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame');
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0.1]]);
+    assert.strictEqual(requestFrame.mock.calls.length, 1);
+
+    onProgress.mockClear();
+    scrollY.mockReturnValue(500);
+    window.dispatchEvent(new Event('scroll'));
+    window.dispatchEvent(new Event('scroll'));
+    window.dispatchEvent(new Event('scroll'));
+
+    assert.strictEqual(requestFrame.mock.calls.length, 2);
+    assert.strictEqual(onProgress.mock.calls.length, 0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0.5]]);
+  });
+
+  it('Resize event should report progress using the updated viewport height', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    const innerHeight = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(500);
+    const onProgress = vi.fn();
+
+    const { act } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[0.5]]);
+
+    onProgress.mockClear();
+    innerHeight.mockReturnValue(1_500);
+    window.dispatchEvent(new Event('resize'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress.mock.calls, [[1]]);
+  });
+
+  it('Changed callback should receive a pending progress update without restarting the animation frame', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    const scrollY = vi.spyOn(window, 'scrollY', 'get').mockReturnValue(100);
+    const onProgress1 = vi.fn();
+    const onProgress2 = vi.fn();
+
+    const { act, rerender } = await renderHook(
+      (props?: { onProgress: (progress: number) => void }) =>
+        useScrollProgress(props!.onProgress),
+      {
+        initialProps: { onProgress: onProgress1 },
+      },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.deepStrictEqual(onProgress1.mock.calls, [[0.1]]);
+    assert.strictEqual(onProgress2.mock.calls.length, 0);
+
+    onProgress1.mockClear();
+    scrollY.mockReturnValue(500);
+    window.dispatchEvent(new Event('scroll'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS / 2);
+    });
+
+    await rerender({ onProgress: onProgress2 });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS / 2);
+    });
+
+    assert.strictEqual(onProgress1.mock.calls.length, 0);
+    assert.strictEqual(onProgress2.mock.calls.length, 1);
+    assert.deepStrictEqual(onProgress2.mock.calls, [[0.5]]);
+  });
+
+  it('Unmount should cancel the pending update and remove document progress listeners', async () => {
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(2_000);
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(1_000);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(500);
+    const onProgress = vi.fn();
+
+    const { act, unmount } = await renderHook(() => useScrollProgress(onProgress));
+
+    await act(async () => {
+      unmount();
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    window.dispatchEvent(new Event('scroll'));
+    window.dispatchEvent(new Event('resize'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RAF_FRAME_DURATION_MS);
+    });
+
+    assert.strictEqual(onProgress.mock.calls.length, 0);
+  });
+});

--- a/packages/react-kit/src/hooks/use-scroll-progress.ts
+++ b/packages/react-kit/src/hooks/use-scroll-progress.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview `useScrollProgress` hook.
+ */
+
+// --------------------------------------------------------------------------------
+// Directive
+// --------------------------------------------------------------------------------
+
+'use client';
+
+// --------------------------------------------------------------------------------
+// Import
+// --------------------------------------------------------------------------------
+
+import { useEffect, useEffectEvent } from 'react';
+
+// --------------------------------------------------------------------------------
+// Export
+// --------------------------------------------------------------------------------
+
+/**
+ * React hook that reports the current document scroll progress.
+ *
+ * Scroll and resize updates are coalesced with `requestAnimationFrame`. The
+ * reported progress is rounded to three decimal places and clamped between
+ * `0` and `1`.
+ *
+ * @param onProgress Callback invoked with the current normalized scroll progress.
+ *
+ * @example
+ * ```tsx
+ * import { useRef } from 'react';
+ * import { useScrollProgress } from '@lumir/react-kit/hooks';
+ *
+ * function Component() {
+ *   const progressRef = useRef<HTMLDivElement>(null);
+ *
+ *   useScrollProgress(progress => {
+ *     progressRef.current?.style.setProperty('--scroll-progress', String(progress));
+ *   });
+ *
+ *   return <div ref={progressRef} />;
+ * }
+ * ```
+ */
+export function useScrollProgress(onProgress: (progress: number) => void): void {
+  const onProgressEvent = useEffectEvent(onProgress);
+
+  useEffect(() => {
+    let rafId: number | null = null;
+
+    function requestProgressUpdate() {
+      if (rafId === null) {
+        rafId = requestAnimationFrame(() => {
+          rafId = null;
+
+          const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+          const progress = maxScroll > 0 ? window.scrollY / maxScroll : 0;
+          const roundedProgress = Math.round(progress * 1_000) / 1_000;
+          const clampedProgress = Math.min(Math.max(roundedProgress, 0), 1);
+
+          onProgressEvent(clampedProgress);
+        });
+      }
+    }
+
+    requestProgressUpdate();
+
+    window.addEventListener('scroll', requestProgressUpdate, { passive: true });
+    window.addEventListener('resize', requestProgressUpdate);
+
+    return () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+
+      window.removeEventListener('scroll', requestProgressUpdate);
+      window.removeEventListener('resize', requestProgressUpdate);
+    };
+  }, []);
+}


### PR DESCRIPTION
This pull request introduces a new `useScrollProgress` React hook to the `@lumir/react-kit/hooks` package, refactors the `ScrollProgress` component in the blog app to use this hook, and adds comprehensive tests and type checks for the new functionality. The main goal is to encapsulate scroll progress tracking logic in a reusable hook, improving code clarity and maintainability.

**Key changes:**

### Feature: New `useScrollProgress` hook

* Added `useScrollProgress` hook to report normalized document scroll progress, coalescing scroll and resize updates with `requestAnimationFrame` and clamping/rounding the result.
* Exported the new hook from `index.ts` and ensured it's included in the package exports.
* Added runtime and type tests for `useScrollProgress` to verify correct behavior and TypeScript signatures. [[1]](diffhunk://#diff-b592266c33c31962be4a7c67a5a608db0878cdc0b8d9b25385d8e2cc10781deeR1-R236) [[2]](diffhunk://#diff-b04edeaecf6f40dd5033463de697089bc4cc295bb6ca4ce42cbcac34fdf62eafR1-R44)
* Updated the hooks package test index to check for the presence and type of `useScrollProgress`. [[1]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR18) [[2]](diffhunk://#diff-6e7397e54592c1f723c6b883d96d062ff5071110feba8e6eaa01e565dbf8102eR66-R70)

### Refactor: Blog scroll progress component

* Refactored `ScrollProgress` in `apps/blog` to use the new `useScrollProgress` hook instead of local effect logic, simplifying the component and improving readability. [[1]](diffhunk://#diff-bbb824e4b7bba25894bb547c819c3f2f968ab008c9dc18611993db981c6c2a14L21-R22) [[2]](diffhunk://#diff-bbb824e4b7bba25894bb547c819c3f2f968ab008c9dc18611993db981c6c2a14L44-L79)
* Updated the CSS for the progress bar to use the `--scroll-progress` variable, which is now set by the hook.